### PR TITLE
28 Refactor transformContainer to get rid of additional container

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "prepare": "husky install",
     "release": "xs bump,build,docs,publish,git-push",
     "serve": "xs serve",
+    "start": "npm run storybook",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build --output-dir docs/storybook",
     "types": "xs types",

--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -292,7 +292,7 @@ export class LayoutSystem
      * Get element from the layout child tree by it's ID
      * @param {string} id - id of the content to be foundS.
      */
-    getChildByID(id: string): LayoutContainer | Container | undefined
+    getChildByID(id: string): Layout | Container | undefined
     {
         return this.content.getByID(id);
     }
@@ -339,7 +339,7 @@ export class LayoutSystem
 }
 
 /** Container with layout system initiated. */
-export class LayoutContainer extends Container
+export class Layout extends Container
 {
     override layout: LayoutSystem;
 
@@ -348,6 +348,24 @@ export class LayoutContainer extends Container
         super();
 
         this.layout = new LayoutSystem(options, this);
+    }
+
+    /** Get {@link SizeController} */
+    get size(): SizeController
+    {
+        return this.layout.size;
+    }
+
+    /** {@link AlignController} */
+    get align(): AlignController
+    {
+        return this.layout.align;
+    }
+
+    /** {@link ContentController} */
+    get content(): ContentController
+    {
+        return this.layout.content;
     }
 
     /** ID of layout, can be used to set styles in the globalStyles object somewhere higher in hierarchal tree. */
@@ -360,6 +378,18 @@ export class LayoutContainer extends Container
     set id(value: string)
     {
         this.layout.id = value;
+    }
+
+    /** Returns with of the container */
+    get contentWidth(): number | undefined
+    {
+        return this.layout.contentWidth;
+    }
+
+    /** Returns height of the container */
+    get contentHeight(): number | undefined
+    {
+        return this.layout.contentHeight;
     }
 
     /** Set the width of layout.  */
@@ -409,7 +439,7 @@ export class LayoutContainer extends Container
      * Get element from the layout system children tree by it's ID
      * @param {string} id - id of the content to be foundS.
      */
-    getChildByID(id: string): LayoutContainer | Container | undefined
+    getChildByID(id: string): Layout | Container | undefined
     {
         return this.layout.getChildByID(id);
     }
@@ -445,8 +475,6 @@ export class LayoutContainer extends Container
         this.layout.resize(parentWidth, parentHeight);
     }
 }
-
-export class Layout extends LayoutContainer {}
 
 declare module '@pixi/display/lib/Container'
 {

--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -52,10 +52,13 @@ import { TextStyle } from '@pixi/text';
  * 	},
  * });
  */
-export class Layout extends Container
+export class LayoutSystem
 {
     protected bg: Graphics | Container;
     protected overflowMask: Graphics;
+
+    /** Container for all layout children. */
+    container: Container;
 
     /** ID of layout, can be used to set styles in the globalStyles object somewhere higher in hierarchal tree. */
     id: string;
@@ -79,10 +82,11 @@ export class Layout extends Container
      * @param options.styles - Styles of the layout. List of available styles can be found in {@link StyleController}.
      * @param options.content - Content of the layout.
      * @param options.globalStyles - Global styles for layout and it's children.
+     * @param container
      */
-    constructor(options?: LayoutOptions)
+    constructor(options?: LayoutOptions, container?: Container)
     {
-        super();
+        this.container = container || new Container();
 
         this.id = options?.id;
 
@@ -132,7 +136,7 @@ export class Layout extends Container
 
             this.bg = background;
 
-            this.addChildAt(this.bg, 0);
+            this.container.addChildAt(this.bg, 0);
         }
         else
         {
@@ -146,7 +150,7 @@ export class Layout extends Container
                 if (!this.bg)
                 {
                     this.bg = new Graphics();
-                    this.addChildAt(this.bg, 0);
+                    this.container.addChildAt(this.bg, 0);
                 }
 
                 let x = 0;
@@ -166,12 +170,15 @@ export class Layout extends Container
 
                 if (this.bg instanceof Graphics)
                 {
-                    this.bg.clear().beginFill(color.hex, color.opacity).drawRoundedRect(x, y, width, height, borderRadius);
+                    this.bg
+                        .clear()
+                        .beginFill(color.hex, color.opacity)
+                        .drawRoundedRect(x, y, width, height, borderRadius);
                 }
             }
             else if (this.bg)
             {
-                this.removeChild(this.bg);
+                this.container.removeChild(this.bg);
                 delete this.bg;
             }
         }
@@ -188,7 +195,7 @@ export class Layout extends Container
             if (!this.overflowMask)
             {
                 this.overflowMask = new Graphics();
-                this.addChild(this.overflowMask);
+                this.container.addChild(this.overflowMask);
             }
 
             let x = 0;
@@ -206,49 +213,63 @@ export class Layout extends Container
                 y -= height * anchorY;
             }
 
-            this.overflowMask.clear().beginFill(0xffffff).drawRoundedRect(x, y, width, height, borderRadius).endFill();
+            this.overflowMask
+                .clear()
+                .beginFill(0xffffff)
+                .drawRoundedRect(x, y, width, height, borderRadius)
+                .endFill();
 
-            this.mask = this.overflowMask;
+            this.container.mask = this.overflowMask;
         }
         else
         {
-            this.mask = null;
+            this.container.mask = null;
             delete this.overflowMask;
         }
     }
 
     /** Returns with of the container */
-    get contentWidth(): number
+    get contentWidth(): number | undefined
     {
-        return super.width;
+        if (!this.container?.parent)
+        {
+            return undefined;
+        }
+
+        return this.container.parent.width;
     }
 
     /** Returns height of the container */
-    get contentHeight(): number
+    get contentHeight(): number | undefined
     {
-        return super.height;
+        if (!this.container?.parent)
+        {
+            return undefined;
+        }
+
+        return this.container.parent.height;
     }
 
     /** Sets the width of layout.  */
-    override set width(value: number)
+    set width(value: number)
     {
         this.size.width = value;
     }
 
     /** Gets the width of layout. */
-    override get width()
+    get width()
     {
         return this.size.width;
     }
 
     /** Sets the height of layout. */
-    override set height(value: number)
+    set height(value: number)
     {
         this.size.height = value;
     }
 
     /** Gets the height of layout. */
-    override get height()
+    get height()
     {
         return this.size.height;
     }
@@ -278,7 +299,7 @@ export class Layout extends Container
      * Get element from the layout child tree by it's ID
      * @param {string} id - id of the content to be foundS.
      */
-    getChildByID(id: string): Layout | Container | undefined
+    getChildByID(id: string): LayoutSystem | Container | undefined
     {
         return this.content.getByID(id);
     }
@@ -291,18 +312,18 @@ export class Layout extends Container
         rootLayout.size.update();
     }
 
-    protected getRootLayout(): Layout
+    protected getRootLayout(): LayoutSystem
     {
-        if (this.parent && this.parent instanceof Layout)
+        if (this.container.parent && this.container.parent.layout)
         {
-            return this.parent.getRootLayout();
+            return this.container.parent.layout.getRootLayout();
         }
 
         return this;
     }
 
     /**
-     * Updates the layout styles and resize/reposition it ant its children basing on new styles.
+     * Updates the layout styles and resize/reposition it and its children basing on new styles.
      * @param styles
      */
     setStyles(styles: Styles)
@@ -324,12 +345,120 @@ export class Layout extends Container
     }
 }
 
+/** Container with layout system initiated. */
+export class LayoutContainer extends Container
+{
+    override layout: LayoutSystem;
+
+    constructor(options?: LayoutOptions)
+    {
+        super();
+
+        this.layout = new LayoutSystem(options, this);
+    }
+
+    /** ID of layout, can be used to set styles in the globalStyles object somewhere higher in hierarchal tree. */
+    get id()
+    {
+        return this.layout.id;
+    }
+
+    /** ID of layout, can be used to set styles in the globalStyles object somewhere higher in hierarchal tree. */
+    set id(value: string)
+    {
+        this.layout.id = value;
+    }
+
+    /** Set the width of layout.  */
+    override set width(value: number)
+    {
+        this.layout.width = value;
+    }
+
+    /** Get the width of layout. */
+    override get width()
+    {
+        return this.layout.width;
+    }
+
+    /** Set the height of layout. */
+    override set height(value: number)
+    {
+        this.layout.height = value;
+    }
+
+    /** Get the height of layout. */
+    override get height()
+    {
+        return this.layout.height;
+    }
+
+    /**
+     * Add content to the layout system and reposition/resize other elements and the layout basing on styles.
+     * @param {Content} content - Content to be added. Can be string, Container, Layout, LayoutOptions or array of those.
+     * Also content can be an object with inner layout ids as a keys, and Content as values.
+     */
+    addContent(content: Content)
+    {
+        this.layout.addContent(content);
+    }
+
+    /**
+     * Remove content from layout system by its id and reposition/resize other elements and the layout basing on styles.
+     * @param {string} id - id of the content to be removed.
+     */
+    removeChildByID(id: string)
+    {
+        this.layout.removeChildByID(id);
+    }
+
+    /**
+     * Get element from the layout system children tree by it's ID
+     * @param {string} id - id of the content to be foundS.
+     */
+    getChildByID(id: string): LayoutSystem | Container | undefined
+    {
+        return this.layout.getChildByID(id);
+    }
+
+    /**
+     * Updates the layout styles and resize/reposition it and its children basing on new styles.
+     * @param styles
+     */
+    setStyles(styles: Styles)
+    {
+        this.layout.setStyles(styles);
+    }
+
+    /** Layout text styles. */
+    get textStyle(): Partial<TextStyle>
+    {
+        return this.layout.textStyle;
+    }
+
+    /** Layout styles. */
+    get style(): Styles
+    {
+        return this.layout.style;
+    }
+
+    /**
+     * Resize method should be called on every parent size change.
+     * @param parentWidth
+     * @param parentHeight
+     */
+    resize(parentWidth: number, parentHeight: number)
+    {
+        this.layout.resize(parentWidth, parentHeight);
+    }
+}
+
 declare module '@pixi/display/lib/Container'
 {
     interface Container
     {
-        initLayout(config?: LayoutOptions): void;
-        layout?: Layout;
+        initLayout(config?: LayoutOptions): Container;
+        layout?: LayoutSystem;
     }
 }
 
@@ -340,12 +469,10 @@ if (!Container.prototype.initLayout)
         {
             if (!this.layout)
             {
-                this.layout = new Layout(options);
-
-                this.addChild(this.layout);
+                this.layout = new LayoutSystem(options, this);
             }
 
             return this;
-        }
+        },
     });
 }

--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -1,12 +1,9 @@
-import { Graphics } from '@pixi/graphics';
 import { Container } from '@pixi/display';
 import { Content, LayoutOptions, Styles } from './utils/types';
 import { AlignController } from './controllers/align/AlignController';
 import { StyleController } from './controllers/StyleController';
 import { SizeController } from './controllers/SizeController';
 import { ContentController } from './controllers/ContentController';
-import { getColor } from './utils/helpers';
-import { Sprite } from '@pixi/sprite';
 import { TextStyle } from '@pixi/text';
 
 /**
@@ -34,12 +31,21 @@ import { TextStyle } from '@pixi/text';
  * container.layout?.setContent({
  *      text: 'Hello World',
  * }); // set content
+ *
+ * Or alternatively:
+ *
+ * const layoutSystem = new LayoutSystem({
+ *      id: 'root',
+ *      content: 'Hello World',
+ *      styles: {
+ *          background: 'black',
+ *      }
+ * }); // create layout system
+ *
+ * app.stage.addChild(layoutSystem.container); // add layout system generated container to the stage
  */
 export class LayoutSystem
 {
-    protected bg: Graphics | Container;
-    protected overflowMask: Graphics;
-
     /** Container for all layout children. */
     container: Container;
 
@@ -103,105 +109,6 @@ export class LayoutSystem
     resize(parentWidth: number, parentHeight: number)
     {
         this.size.update(parentWidth, parentHeight);
-    }
-
-    /** Render and update the background of layout basing on it's current state. */
-    updateBG()
-    {
-        const { background } = this.style;
-
-        if (background instanceof Container)
-        {
-            if (background instanceof Sprite)
-            {
-                background.anchor.set(0);
-            }
-
-            this.bg = background;
-
-            this.container.addChildAt(this.bg, 0);
-        }
-        else
-        {
-            const color = background !== 'transparent' && getColor(background);
-
-            const { borderRadius } = this.style;
-            const { width, height } = this;
-
-            if (color && width && height)
-            {
-                if (!this.bg)
-                {
-                    this.bg = new Graphics();
-                    this.container.addChildAt(this.bg, 0);
-                }
-
-                let x = 0;
-                let y = 0;
-
-                const { anchorX, anchorY } = this.style;
-
-                if (anchorX !== undefined)
-                {
-                    x -= width * anchorX;
-                }
-
-                if (anchorY !== undefined)
-                {
-                    y -= height * anchorY;
-                }
-
-                if (this.bg instanceof Graphics)
-                {
-                    this.bg.clear().beginFill(color.hex, color.opacity).drawRoundedRect(x, y, width, height, borderRadius);
-                }
-            }
-            else if (this.bg)
-            {
-                this.container.removeChild(this.bg);
-                delete this.bg;
-            }
-        }
-    }
-
-    /** Render and update the mask of layout basing on it's current state. Mask is used to hide overflowing content. */
-    updateMask()
-    {
-        const { overflow, borderRadius } = this.style;
-        const { width, height } = this;
-
-        if (overflow === 'hidden' && width && height)
-        {
-            if (!this.overflowMask)
-            {
-                this.overflowMask = new Graphics();
-                this.container.addChild(this.overflowMask);
-            }
-
-            let x = 0;
-            let y = 0;
-
-            const { anchorX, anchorY } = this.style;
-
-            if (anchorX !== undefined)
-            {
-                x -= width * anchorX;
-            }
-
-            if (anchorY !== undefined)
-            {
-                y -= height * anchorY;
-            }
-
-            this.overflowMask.clear().beginFill(0xffffff).drawRoundedRect(x, y, width, height, borderRadius).endFill();
-
-            this.container.mask = this.overflowMask;
-        }
-        else
-        {
-            this.container.mask = null;
-            delete this.overflowMask;
-        }
     }
 
     /** Returns with of the container */

--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -292,7 +292,7 @@ export class LayoutSystem
      * Get element from the layout child tree by it's ID
      * @param {string} id - id of the content to be foundS.
      */
-    getChildByID(id: string): LayoutSystem | Container | undefined
+    getChildByID(id: string): LayoutContainer | Container | undefined
     {
         return this.content.getByID(id);
     }
@@ -302,17 +302,17 @@ export class LayoutSystem
     {
         const rootLayout = this.getRootLayout();
 
-        rootLayout.size.update();
+        rootLayout.layout.size.update();
     }
 
-    protected getRootLayout(): LayoutSystem
+    protected getRootLayout(): Container
     {
-        if (this.container.parent && this.container.parent.layout)
+        if (this.container.parent?.layout)
         {
             return this.container.parent.layout.getRootLayout();
         }
 
-        return this;
+        return this.container;
     }
 
     /**
@@ -409,7 +409,7 @@ export class LayoutContainer extends Container
      * Get element from the layout system children tree by it's ID
      * @param {string} id - id of the content to be foundS.
      */
-    getChildByID(id: string): LayoutSystem | Container | undefined
+    getChildByID(id: string): LayoutContainer | Container | undefined
     {
         return this.layout.getChildByID(id);
     }

--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -10,47 +10,30 @@ import { Sprite } from '@pixi/sprite';
 import { TextStyle } from '@pixi/text';
 
 /**
- * Universal layout class for Pixi.js.
+ * Layout controller class for any PixiJS Container based instance.
  *
- * You can consider layout as div from CSS.
+ * To be be used for automatic align and resize children tree,
+ * where every child behavior can be configured using css like configurations.
  *
- * It will be rendered as PIXI.Container and can be used for automatic align and resize blocks and text.
+ * Also it adds a list of css-like properties for styling like background style or text style,
+ * check {@link SizeController} class.
  *
- * Also it brings a list of css-like properties for styling itself and it's children.
- *
- * Children will be resized and aligned to fit parent size, if they have width and height properties
- *
- * (like Sprite or Graphics instances from Pixi.js)
+ * Any PixiJS Container based instance can be turned into a layout by calling {@link Layout#initLayout} method.
  * @example
- * const layout = new Layout({
- * 	id: 'myLayout',
- * 	styles: {
- * 		width: 100,
- * 		height: 100,
- * 		background: 'red',
- * 	},
- * 	content: [
- * 		'Hello world',
- * 		{
- * 			id: 'innerLayout1',
- * 			text: 'Inner layout 1',
- * 		},
- * 		{
- * 			id: 'innerLayout2',
- * 			text: 'Inner layout 2',
- * 		},
- * 	],
- * 	globalStyles: {
- * 		innerLayout1: {
- * 			width: 200,
- * 			height: 200,
- * 		},
- * 		innerLayout1: {
- * 			width: 200,
- * 			height: 200,
- * 		},
- * 	},
- * });
+ * const layout = new Container().initLayout();
+ *
+ * layout.layout?.setStyles({
+ *      background: 'black',
+ *      width: '100%',
+ *      height: '100%',
+ *      padding: 10,
+ *      overflow: 'hidden',
+ *      color: 'white',
+ * }); // set styles
+ *
+ * layout.layout?.setContent({
+ *      text: 'Hello World',
+ * }); // set content
  */
 export class LayoutSystem
 {
@@ -76,13 +59,13 @@ export class LayoutSystem
     content: ContentController;
 
     /**
-     * Creates layout
+     * Creates layout system instance.
      * @param options - Layout options
      * @param options.id - ID of the layout.
      * @param options.styles - Styles of the layout. List of available styles can be found in {@link StyleController}.
      * @param options.content - Content of the layout.
      * @param options.globalStyles - Global styles for layout and it's children.
-     * @param container
+     * @param container - Container for all layout children, will be created if not provided.
      */
     constructor(options?: LayoutOptions, container?: Container)
     {
@@ -338,11 +321,47 @@ export class LayoutSystem
     }
 }
 
-/** Container with layout system initiated. */
+/**
+ * Container with layout system initiated.
+ * @example
+ *
+ * const layout = new Layout({
+ * 	styles: {
+ * 		width: 100,
+ * 		height: 100,
+ * 		background: 'red',
+ * 	},
+ * 	content: [
+ * 		'Hello world',
+ * 		{
+ * 			id: 'innerLayout1',
+ * 			text: 'Inner layout 1',
+ * 		},
+ * 		{
+ * 			id: 'innerLayout2',
+ * 			text: 'Inner layout 2',
+ * 		},
+ * 	],
+ * 	globalStyles: {
+ * 		innerLayout1: {
+ * 			width: 200,
+ * 			height: 200,
+ * 		},
+ * 		innerLayout1: {
+ * 			width: 200,
+ * 			height: 200,
+ * 		},
+ * 	},
+ * });
+ */
 export class Layout extends Container
 {
     override layout: LayoutSystem;
 
+    /**
+     * Creates layout container.
+     * @param options
+     */
     constructor(options?: LayoutOptions)
     {
         super();
@@ -368,25 +387,25 @@ export class Layout extends Container
         return this.layout.content;
     }
 
-    /** ID of layout, can be used to set styles in the globalStyles object somewhere higher in hierarchal tree. */
+    /** ID of layout, can be used to set styles in the globalStyles. */
     get id()
     {
         return this.layout.id;
     }
 
-    /** ID of layout, can be used to set styles in the globalStyles object somewhere higher in hierarchal tree. */
+    /** ID of layout, can be used to set styles in the globalStyles. */
     set id(value: string)
     {
         this.layout.id = value;
     }
 
-    /** Returns with of the container */
+    /** Returns with of the layouts content. */
     get contentWidth(): number | undefined
     {
         return this.layout.contentWidth;
     }
 
-    /** Returns height of the container */
+    /** Returns height of the layouts content. */
     get contentHeight(): number | undefined
     {
         return this.layout.contentHeight;
@@ -417,9 +436,9 @@ export class Layout extends Container
     }
 
     /**
-     * Add content to the layout system and reposition/resize other elements and the layout basing on styles.
+     * Add content to the layout system and reposition/resize elements basing on styles.
      * @param {Content} content - Content to be added. Can be string, Container, Layout, LayoutOptions or array of those.
-     * Also content can be an object with inner layout ids as a keys, and Content as values.
+     * Also content can be an object where keys are ids of child layouts to create, and Content as values.
      */
     addContent(content: Content)
     {
@@ -427,7 +446,7 @@ export class Layout extends Container
     }
 
     /**
-     * Remove content from layout system by its id and reposition/resize other elements and the layout basing on styles.
+     * Remove content from layout system by its id and reposition/resize elements basing on styles.
      * @param {string} id - id of the content to be removed.
      */
     removeChildByID(id: string)
@@ -445,7 +464,7 @@ export class Layout extends Container
     }
 
     /**
-     * Updates the layout styles and resize/reposition it and its children basing on new styles.
+     * Updates the layout styles and resize/reposition elements basing on new styles.
      * @param styles
      */
     setStyles(styles: Styles)

--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -446,6 +446,8 @@ export class LayoutContainer extends Container
     }
 }
 
+export class Layout extends LayoutContainer {}
+
 declare module '@pixi/display/lib/Container'
 {
     interface Container

--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -170,10 +170,7 @@ export class LayoutSystem
 
                 if (this.bg instanceof Graphics)
                 {
-                    this.bg
-                        .clear()
-                        .beginFill(color.hex, color.opacity)
-                        .drawRoundedRect(x, y, width, height, borderRadius);
+                    this.bg.clear().beginFill(color.hex, color.opacity).drawRoundedRect(x, y, width, height, borderRadius);
                 }
             }
             else if (this.bg)
@@ -213,11 +210,7 @@ export class LayoutSystem
                 y -= height * anchorY;
             }
 
-            this.overflowMask
-                .clear()
-                .beginFill(0xffffff)
-                .drawRoundedRect(x, y, width, height, borderRadius)
-                .endFill();
+            this.overflowMask.clear().beginFill(0xffffff).drawRoundedRect(x, y, width, height, borderRadius).endFill();
 
             this.container.mask = this.overflowMask;
         }
@@ -473,6 +466,6 @@ if (!Container.prototype.initLayout)
             }
 
             return this;
-        },
+        }
     });
 }

--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -20,9 +20,9 @@ import { TextStyle } from '@pixi/text';
  *
  * Any PixiJS Container based instance can be turned into a layout by calling {@link Layout#initLayout} method.
  * @example
- * const layout = new Container().initLayout();
+ * const container = new Container().initLayout();
  *
- * layout.layout?.setStyles({
+ * container.layout?.setStyles({
  *      background: 'black',
  *      width: '100%',
  *      height: '100%',
@@ -31,7 +31,7 @@ import { TextStyle } from '@pixi/text';
  *      color: 'white',
  * }); // set styles
  *
- * layout.layout?.setContent({
+ * container.layout?.setContent({
  *      text: 'Hello World',
  * }); // set content
  */

--- a/src/controllers/ContentController.ts
+++ b/src/controllers/ContentController.ts
@@ -101,7 +101,7 @@ export class ContentController
                     layoutConfig.id = `layout-${customID}`;
                 }
 
-                this.addContentElement(layoutConfig.id, new Container().initLayout(layoutConfig));
+                this.addContentElement(layoutConfig.id, new LayoutContainer(layoutConfig));
                 break;
             case 'object':
                 const contentList = content as ContentList[];
@@ -224,7 +224,7 @@ export class ContentController
     {
         this.children.forEach((child) =>
         {
-            if (child instanceof LayoutSystem)
+            if (child instanceof LayoutContainer)
             {
                 child.resize(width, height);
             }

--- a/src/controllers/ContentController.ts
+++ b/src/controllers/ContentController.ts
@@ -1,22 +1,12 @@
 /* eslint-disable no-prototype-builtins */
 /* eslint-disable no-case-declarations */
 import { Layout, LayoutSystem } from '../Layout';
-import { Content, ContentList, LayoutOptions, LayoutStyles } from '../utils/types';
+import { Content, ContentList, ContentType, LayoutOptions, LayoutStyles } from '../utils/types';
 import { Container } from '@pixi/display';
 import { Text } from '@pixi/text';
 import { Sprite } from '@pixi/sprite';
 import { Graphics } from '@pixi/graphics';
 import { stylesToPixiTextStyles } from '../utils/helpers';
-
-type ContentType =
-    | 'layout'
-    | 'text'
-    | 'string'
-    | 'container'
-    | 'array'
-    | 'unknown'
-    | 'layoutConfig'
-    | 'object';
 
 /** Controls all {@link LayoutSystem} children sizing. */
 export class ContentController

--- a/src/controllers/ContentController.ts
+++ b/src/controllers/ContentController.ts
@@ -248,9 +248,9 @@ export class ContentController
         {
             this.children.forEach((child) =>
             {
-                if (child instanceof LayoutSystem)
+                if (child.layout)
                 {
-                    const res = child.content.getByID(id);
+                    const res = child.layout.content.getByID(id);
 
                     if (res)
                     {

--- a/src/controllers/ContentController.ts
+++ b/src/controllers/ContentController.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-prototype-builtins */
 /* eslint-disable no-case-declarations */
-import { LayoutContainer, LayoutSystem } from '../Layout';
+import { Layout, LayoutSystem } from '../Layout';
 import { Content, ContentList, LayoutOptions, LayoutStyles } from '../utils/types';
 import { Container } from '@pixi/display';
 import { Text } from '@pixi/text';
@@ -60,7 +60,7 @@ export class ContentController
         switch (contentType)
         {
             case 'layout':
-                const layout = content as LayoutContainer;
+                const layout = content as Layout;
 
                 this.addContentElement(layout.id, layout);
                 break;
@@ -101,7 +101,7 @@ export class ContentController
                     layoutConfig.id = `layout-${customID}`;
                 }
 
-                this.addContentElement(layoutConfig.id, new LayoutContainer(layoutConfig));
+                this.addContentElement(layoutConfig.id, new Layout(layoutConfig));
                 break;
             case 'object':
                 const contentList = content as ContentList[];
@@ -148,7 +148,7 @@ export class ContentController
                             this.addContentElement(idKey, textInstance);
                             break;
                         case 'layout':
-                            const layoutInstance = contentElement as LayoutContainer;
+                            const layoutInstance = contentElement as Layout;
 
                             if (parentGlobalStyles && parentGlobalStyles[idKey])
                             {
@@ -224,7 +224,7 @@ export class ContentController
     {
         this.children.forEach((child) =>
         {
-            if (child instanceof LayoutContainer)
+            if (child instanceof Layout)
             {
                 child.resize(width, height);
             }
@@ -267,7 +267,7 @@ export class ContentController
     {
         if (typeof content === 'string') return 'string';
 
-        if (content instanceof LayoutContainer) return 'layout';
+        if (content instanceof Layout) return 'layout';
 
         if (content instanceof Text) return 'text';
 

--- a/src/controllers/SizeController.ts
+++ b/src/controllers/SizeController.ts
@@ -1,14 +1,14 @@
 /* eslint-disable no-case-declarations */
 import { getNumber, isItJustAText } from '../utils/helpers';
-import { Layout } from '../Layout';
+import { LayoutSystem } from '../Layout';
 import { Text } from '@pixi/text';
 import { Container } from '@pixi/display';
 import { FlexNumber, SizeControl } from '../utils/types';
 
-/** Size controller manages {@link Layout} and it's content size. */
+/** Size controller manages {@link LayoutSystem} and it's content size. */
 export class SizeController
 {
-    protected layout: Layout;
+    protected layout: LayoutSystem;
     protected _width: number;
     protected _height: number;
 
@@ -17,9 +17,9 @@ export class SizeController
 
     /**
      * Creates size controller.
-     * @param {Layout} layout - Layout to control.
+     * @param {LayoutSystem} layout - Layout to control.
      */
-    constructor(layout: Layout)
+    constructor(layout: LayoutSystem)
     {
         this.layout = layout;
     }
@@ -58,12 +58,12 @@ export class SizeController
             paddingRight,
             paddingTop,
             paddingBottom,
-            aspectRatio
+            aspectRatio,
         } = this.layout.style;
 
         if (width === 0 || height === 0)
         {
-            this.layout.visible = false;
+            this.layout.container.visible = false;
 
             return;
         }
@@ -76,7 +76,8 @@ export class SizeController
                     // width is auto, there is only 1 child and it is text
                     // resize basing on text width
 
-                    const needToBeResized = this.innerText.width + paddingLeft + paddingRight > this.parentWidth;
+                    const needToBeResized
+                        = this.innerText.width + paddingLeft + paddingRight > this.parentWidth;
 
                     if (!this.innerText.style.wordWrap && needToBeResized)
                     {
@@ -85,7 +86,8 @@ export class SizeController
 
                     if (this.innerText.style.wordWrap)
                     {
-                        this.innerText.style.wordWrapWidth = this.parentWidth - paddingLeft - paddingRight;
+                        this.innerText.style.wordWrapWidth
+                            = this.parentWidth - paddingLeft - paddingRight;
                     }
 
                     finalWidth = this.innerText.width;
@@ -109,9 +111,12 @@ export class SizeController
                     const { firstChild } = this.layout.content;
 
                     // add first element as at lease one element to set width
-                    if (firstChild instanceof Layout)
+                    if (firstChild instanceof LayoutSystem)
                     {
-                        childrenWidth += firstChild.width + firstChild.style.marginLeft + firstChild.style.marginRight;
+                        childrenWidth
+                            += firstChild.width
+                            + firstChild.style.marginLeft
+                            + firstChild.style.marginRight;
                     }
                     else if (firstChild instanceof Container && firstChild.width)
                     {
@@ -126,7 +131,7 @@ export class SizeController
                             return;
                         }
 
-                        if (child instanceof Layout && child.style.display !== 'block')
+                        if (child instanceof LayoutSystem && child.style.display !== 'block')
                         {
                             if (child.style.position)
                             {
@@ -159,7 +164,8 @@ export class SizeController
                     if (isItJustAText(this.layout))
                     {
                         this.innerText.style.wordWrap = true;
-                        this.innerText.style.wordWrapWidth = parentWidth - paddingLeft - paddingRight;
+                        this.innerText.style.wordWrapWidth
+                            = parentWidth - paddingLeft - paddingRight;
                     }
 
                     break;
@@ -202,7 +208,7 @@ export class SizeController
                     const { firstChild } = this.layout.content;
 
                     // add first element as at lease one element to set width
-                    if (firstChild instanceof Layout)
+                    if (firstChild instanceof LayoutSystem)
                     {
                         if (!firstChild.style.position)
                         {
@@ -222,13 +228,13 @@ export class SizeController
                             return;
                         }
 
-                        if (child instanceof Layout && child.style.position)
+                        if (child instanceof LayoutSystem && child.style.position)
                         {
                             // skip absolute positioned elements
                             return;
                         }
 
-                        if (child instanceof Layout)
+                        if (child instanceof LayoutSystem)
                         {
                             if (child.style.display === 'block')
                             {
@@ -262,9 +268,9 @@ export class SizeController
         }
 
         // apply parent paddings
-        if (this.layout.parent instanceof Layout)
+        if (this.layout.container.parent?.layout)
         {
-            const { paddingLeft, paddingRight } = this.layout.parent?.style;
+            const { paddingLeft, paddingRight } = this.layout.container.parent?.layout.style;
 
             const parentPaddingLeft = paddingLeft ?? 0;
             const parentPaddingRight = paddingRight ?? 0;
@@ -289,7 +295,7 @@ export class SizeController
 
         if (finalWidth === 0 || finalHeight === 0)
         {
-            this.layout.visible = false;
+            this.layout.container.visible = false;
 
             return;
         }
@@ -297,7 +303,7 @@ export class SizeController
         this._width = getNumber(finalWidth, this.parentWidth);
         this._height = getNumber(finalHeight, this.parentHeight);
 
-        this.layout.scale.set(scaleX, scaleY);
+        this.layout.container.scale.set(scaleX, scaleY);
 
         if (aspectRatio === 'flex' || maxWidth || maxHeight || minWidth || minHeight)
         {
@@ -406,8 +412,8 @@ export class SizeController
         const { maxWidth, maxHeight, minWidth, minHeight, aspectRatio } = this.layout.style;
         const { marginLeft, marginRight, marginBottom, marginTop } = this.layout.style;
 
-        const currentScaleX = this.layout.scale.x;
-        const currentScaleY = this.layout.scale.y;
+        const currentScaleX = this.layout.container.scale.x;
+        const currentScaleY = this.layout.container.scale.y;
 
         const layoutWidth = this.layout.width + marginLeft + marginRight;
         const layoutHeight = this.layout.height + marginTop + marginBottom;
@@ -447,11 +453,12 @@ export class SizeController
 
             if (minWidthScale || minHeightScale)
             {
-                const scale = (minWidthScale && minHeightScale)
-                    ? Math.min(minWidthScale, minHeightScale)
-                    : minWidthScale ?? minHeightScale;
+                const scale
+                    = minWidthScale && minHeightScale
+                        ? Math.min(minWidthScale, minHeightScale)
+                        : minWidthScale ?? minHeightScale;
 
-                this.layout.scale.set(scale);
+                this.layout.container.scale.set(scale);
             }
 
             return;
@@ -495,6 +502,6 @@ export class SizeController
             finalScaleToFit = Math.max(finalMinScaleToFit, finalMinScaleToFit);
         }
 
-        this.layout.scale.set(finalScaleToFit);
+        this.layout.container.scale.set(finalScaleToFit);
     }
 }

--- a/src/controllers/SizeController.ts
+++ b/src/controllers/SizeController.ts
@@ -59,6 +59,7 @@ export class SizeController
             paddingTop,
             paddingBottom,
             aspectRatio,
+            position,
         } = this.layout.style;
 
         if (width === 0 || height === 0)
@@ -111,12 +112,12 @@ export class SizeController
                     const { firstChild } = this.layout.content;
 
                     // add first element as at lease one element to set width
-                    if (firstChild instanceof LayoutSystem)
+                    if (firstChild && firstChild.layout)
                     {
                         childrenWidth
                             += firstChild.width
-                            + firstChild.style.marginLeft
-                            + firstChild.style.marginRight;
+                            + firstChild.layout.style.marginLeft
+                            + firstChild.layout.style.marginRight;
                     }
                     else if (firstChild instanceof Container && firstChild.width)
                     {
@@ -131,14 +132,14 @@ export class SizeController
                             return;
                         }
 
-                        if (child instanceof LayoutSystem && child.style.display !== 'block')
+                        if (child.layout && child.layout.style.display !== 'block')
                         {
-                            if (child.style.position)
+                            if (child.layout.style.position)
                             {
                                 return;
                             }
 
-                            childrenWidth += child.width + child.style.marginLeft;
+                            childrenWidth += child.width + child.layout.style.marginLeft;
                         }
                         else if (child instanceof Container && child.width)
                         {
@@ -208,9 +209,9 @@ export class SizeController
                     const { firstChild } = this.layout.content;
 
                     // add first element as at lease one element to set width
-                    if (firstChild instanceof LayoutSystem)
+                    if (firstChild && firstChild.layout)
                     {
-                        if (!firstChild.style.position)
+                        if (!firstChild.layout.style.position)
                         {
                             childrenHeight += firstChild.height;
                         }
@@ -228,15 +229,15 @@ export class SizeController
                             return;
                         }
 
-                        if (child instanceof LayoutSystem && child.style.position)
+                        if (child.layout && child.layout.style.position)
                         {
                             // skip absolute positioned elements
                             return;
                         }
 
-                        if (child instanceof LayoutSystem)
+                        if (child.layout)
                         {
-                            if (child.style.display === 'block')
+                            if (child.layout.style.display === 'block')
                             {
                                 childrenHeight += child.height;
                             }
@@ -268,7 +269,7 @@ export class SizeController
         }
 
         // apply parent paddings
-        if (this.layout.container.parent?.layout)
+        if (this.layout.container.parent?.layout && !position)
         {
             const { paddingLeft, paddingRight } = this.layout.container.parent?.layout.style;
 

--- a/src/controllers/StyleController.ts
+++ b/src/controllers/StyleController.ts
@@ -2,12 +2,12 @@ import type { GradeToOne, Styles } from '../utils/types';
 import { TextStyle } from '@pixi/text';
 import { stylesToPixiTextStyles } from '../utils/helpers';
 import { OVERFLOW, VERTICAL_ALIGN } from '../utils/constants';
-import { Layout } from '../Layout';
+import { LayoutSystem } from '../Layout';
 
-/** Style controller manages {@link Layout} styles. */
+/** Style controller manages {@link LayoutSystem} styles. */
 export class StyleController
 {
-    protected layout: Layout;
+    protected layout: LayoutSystem;
 
     protected styles: Styles = {};
 
@@ -15,11 +15,11 @@ export class StyleController
     protected _textStyle: Partial<TextStyle> = {}; // this is to be nested by children
 
     /**
-     * Manages and sets all the styles of {@link Layout}
-     * @param layout - {@link Layout} to be styled
+     * Manages and sets all the styles of {@link LayoutSystem}
+     * @param layout - {@link LayoutSystem} to be styled
      * @param styles - styles to be applied
      */
-    constructor(layout: Layout, styles?: Styles)
+    constructor(layout: LayoutSystem, styles?: Styles)
     {
         this.layout = layout;
         if (styles)
@@ -49,16 +49,23 @@ export class StyleController
         this.styles.minHeight = styles?.minHeight ?? this.styles.minHeight;
 
         this.styles.padding = styles?.padding ?? this.styles.padding ?? 0;
-        this.styles.paddingTop = styles?.paddingTop ?? styles?.padding ?? this.styles.paddingTop ?? 0;
-        this.styles.paddingRight = styles?.paddingRight ?? styles?.padding ?? this.styles.paddingRight ?? 0;
-        this.styles.paddingBottom = styles?.paddingBottom ?? styles?.padding ?? this.styles.paddingBottom ?? 0;
-        this.styles.paddingLeft = styles?.paddingLeft ?? styles?.padding ?? this.styles.paddingLeft ?? 0;
+        this.styles.paddingTop
+            = styles?.paddingTop ?? styles?.padding ?? this.styles.paddingTop ?? 0;
+        this.styles.paddingRight
+            = styles?.paddingRight ?? styles?.padding ?? this.styles.paddingRight ?? 0;
+        this.styles.paddingBottom
+            = styles?.paddingBottom ?? styles?.padding ?? this.styles.paddingBottom ?? 0;
+        this.styles.paddingLeft
+            = styles?.paddingLeft ?? styles?.padding ?? this.styles.paddingLeft ?? 0;
 
         this.styles.margin = styles?.margin ?? this.styles.margin ?? 0;
         this.styles.marginTop = styles?.marginTop ?? styles?.margin ?? this.styles.marginTop ?? 0;
-        this.styles.marginRight = styles?.marginRight ?? styles?.margin ?? this.styles.marginRight ?? 0;
-        this.styles.marginBottom = styles?.marginBottom ?? styles?.margin ?? this.styles.marginBottom ?? 0;
-        this.styles.marginLeft = styles?.marginLeft ?? styles?.margin ?? this.styles.marginLeft ?? 0;
+        this.styles.marginRight
+            = styles?.marginRight ?? styles?.margin ?? this.styles.marginRight ?? 0;
+        this.styles.marginBottom
+            = styles?.marginBottom ?? styles?.margin ?? this.styles.marginBottom ?? 0;
+        this.styles.marginLeft
+            = styles?.marginLeft ?? styles?.margin ?? this.styles.marginLeft ?? 0;
 
         this.styles.scale = styles?.scale ?? this.styles.scale ?? 1;
         this.styles.scaleX = styles?.scaleX ?? styles?.scale ?? this.styles.scaleX ?? 1;
@@ -99,11 +106,13 @@ export class StyleController
             }
         }
 
-        this.styles.background = styles?.background ?? styles?.backgroundColor ?? this.styles.background;
+        this.styles.background
+            = styles?.background ?? styles?.backgroundColor ?? this.styles.background;
 
         this.styles.textAlign = styles?.textAlign ?? this.styles.textAlign;
         this.styles.position = styles?.position ?? this.styles.position;
-        this.styles.verticalAlign = styles?.verticalAlign ?? this.styles.verticalAlign ?? VERTICAL_ALIGN[0];
+        this.styles.verticalAlign
+            = styles?.verticalAlign ?? this.styles.verticalAlign ?? VERTICAL_ALIGN[0];
 
         this.styles.aspectRatio = styles?.aspectRatio ?? this.styles.aspectRatio ?? 'static';
 
@@ -135,7 +144,7 @@ export class StyleController
     set opacity(value: GradeToOne)
     {
         this.styles.opacity = value;
-        this.layout.alpha = value;
+        this.layout.container.alpha = value;
     }
 
     /** Returns the opacity of the layout */

--- a/src/controllers/align/AlignController.ts
+++ b/src/controllers/align/AlignController.ts
@@ -1,4 +1,4 @@
-import { LayoutSystem } from '../../Layout';
+import { LayoutContainer, LayoutSystem } from '../../Layout';
 import { Text } from '@pixi/text';
 import { isItJustAText } from '../../utils/helpers';
 
@@ -118,7 +118,7 @@ export class AlignController
             let childMarginTop = 0;
             let childMarginBottom = 0;
 
-            if (child instanceof LayoutSystem)
+            if (child instanceof LayoutContainer)
             {
                 childDisplay = child.style.display;
                 const childPosition = child.style.position;
@@ -205,55 +205,60 @@ export class AlignController
         const anchorX = style.anchorX;
         const anchorY = style.anchorY;
 
+        const finalPosition = {
+            x: 0,
+            y: 0,
+        };
+
         switch (position)
         {
             case 'rightTop':
             case 'topRight':
             case 'right':
-                this.layout.container.x = parentWidth - marginRight - (width * (anchorX ?? 1));
-                this.layout.container.y = marginTop - (height * (anchorY ?? 0));
+                finalPosition.x = parentWidth - marginRight - (width * (anchorX ?? 1));
+                finalPosition.y = marginTop - (height * (anchorY ?? 0));
                 break;
 
             case 'leftBottom':
             case 'bottomLeft':
             case 'bottom':
-                this.layout.container.x = marginLeft - (width * (anchorX ?? 0));
-                this.layout.container.y = parentHeight - marginBottom - (height * (anchorY ?? 1));
+                finalPosition.x = marginLeft - (width * (anchorX ?? 0));
+                finalPosition.y = parentHeight - marginBottom - (height * (anchorY ?? 1));
                 break;
 
             case 'rightBottom':
             case 'bottomRight':
-                this.layout.container.x = parentWidth - marginRight - (width * (anchorX ?? 1));
-                this.layout.container.y = parentHeight - marginBottom - (height * (anchorY ?? 1));
+                finalPosition.x = parentWidth - marginRight - (width * (anchorX ?? 1));
+                finalPosition.y = parentHeight - marginBottom - (height * (anchorY ?? 1));
                 break;
 
             case 'center':
-                this.layout.container.x = (parentWidth / 2) - (width * (anchorX ?? 0.5)) + marginLeft;
-                this.layout.container.y = (parentHeight / 2) - (height * (anchorY ?? 0.5)) + marginTop;
+                finalPosition.x = (parentWidth / 2) - (width * (anchorX ?? 0.5)) + marginLeft;
+                finalPosition.y = (parentHeight / 2) - (height * (anchorY ?? 0.5)) + marginTop;
                 break;
 
             case 'centerTop':
             case 'topCenter':
-                this.layout.container.x = (parentWidth / 2) - (width * (anchorX ?? 0.5)) + marginLeft;
-                this.layout.container.y = marginTop - (height * (anchorY ?? 0));
+                finalPosition.x = (parentWidth / 2) - (width * (anchorX ?? 0.5)) + marginLeft;
+                finalPosition.y = marginTop - (height * (anchorY ?? 0));
                 break;
 
             case 'centerBottom':
             case 'bottomCenter':
-                this.layout.container.x = (parentWidth / 2) - (width * (anchorX ?? 0.5)) + marginLeft;
-                this.layout.container.y = parentHeight - marginBottom - (height * (anchorY ?? 1));
+                finalPosition.x = (parentWidth / 2) - (width * (anchorX ?? 0.5)) + marginLeft;
+                finalPosition.y = parentHeight - marginBottom - (height * (anchorY ?? 1));
                 break;
 
             case 'centerLeft':
             case 'leftCenter':
-                this.layout.container.x = marginLeft - (width * (anchorX ?? 0));
-                this.layout.container.y = (parentHeight / 2) - (height * (anchorY ?? 0.5)) + marginTop;
+                finalPosition.x = marginLeft - (width * (anchorX ?? 0));
+                finalPosition.y = (parentHeight / 2) - (height * (anchorY ?? 0.5)) + marginTop;
                 break;
 
             case 'centerRight':
             case 'rightCenter':
-                this.layout.container.x = parentWidth - marginRight - (width * (anchorX ?? 1));
-                this.layout.container.y = (parentHeight / 2) - (height * (anchorY ?? 0.5)) + marginTop;
+                finalPosition.x = parentWidth - marginRight - (width * (anchorX ?? 1));
+                finalPosition.y = (parentHeight / 2) - (height * (anchorY ?? 0.5)) + marginTop;
                 break;
 
             case 'leftTop':
@@ -261,8 +266,10 @@ export class AlignController
             case 'left':
             case 'top':
             default:
-                this.layout.container.x = marginLeft - (width * (anchorX ?? 0));
-                this.layout.container.y = marginTop - (height * (anchorY ?? 0));
+                finalPosition.x = marginLeft - (width * (anchorX ?? 0));
+                finalPosition.y = marginTop - (height * (anchorY ?? 0));
         }
+
+        this.layout.container.position.set(finalPosition.x, finalPosition.y);
     }
 }

--- a/src/controllers/align/AlignController.ts
+++ b/src/controllers/align/AlignController.ts
@@ -1,17 +1,17 @@
-import { Layout } from '../../Layout';
+import { LayoutSystem } from '../../Layout';
 import { Text } from '@pixi/text';
 import { isItJustAText } from '../../utils/helpers';
 
-/** Align controller manages {@link Layout} and it's content alignment. */
+/** Align controller manages {@link LayoutSystem} and it's content alignment. */
 export class AlignController
 {
-    protected layout: Layout;
+    protected layout: LayoutSystem;
 
     /**
      * Creates align controller.
-     * @param {Layout} layout - Layout to control.
+     * @param {LayoutSystem} layout - Layout to control.
      */
-    constructor(layout: Layout)
+    constructor(layout: LayoutSystem)
     {
         this.layout = layout;
     }
@@ -118,7 +118,7 @@ export class AlignController
             let childMarginTop = 0;
             let childMarginBottom = 0;
 
-            if (child instanceof Layout)
+            if (child instanceof LayoutSystem)
             {
                 childDisplay = child.style.display;
                 const childPosition = child.style.position;
@@ -190,14 +190,15 @@ export class AlignController
 
     protected setSelfPosition(parentWidth: number, parentHeight: number)
     {
-        const { position, marginRight, marginBottom, marginTop, marginLeft } = this.layout.style || {};
+        const { position, marginRight, marginBottom, marginTop, marginLeft }
+            = this.layout.style || {};
 
         const { style } = this.layout;
 
         if (!position) return;
 
-        const scaleX = this.layout.scale.x;
-        const scaleY = this.layout.scale.y;
+        const scaleX = this.layout.container.scale.x;
+        const scaleY = this.layout.container.scale.y;
         const width = this.layout.width * scaleX;
         const height = this.layout.height * scaleY;
 
@@ -209,50 +210,50 @@ export class AlignController
             case 'rightTop':
             case 'topRight':
             case 'right':
-                this.layout.x = parentWidth - marginRight - (width * (anchorX ?? 1));
-                this.layout.y = marginTop - (height * (anchorY ?? 0));
+                this.layout.container.x = parentWidth - marginRight - (width * (anchorX ?? 1));
+                this.layout.container.y = marginTop - (height * (anchorY ?? 0));
                 break;
 
             case 'leftBottom':
             case 'bottomLeft':
             case 'bottom':
-                this.layout.x = marginLeft - (width * (anchorX ?? 0));
-                this.layout.y = parentHeight - marginBottom - (height * (anchorY ?? 1));
+                this.layout.container.x = marginLeft - (width * (anchorX ?? 0));
+                this.layout.container.y = parentHeight - marginBottom - (height * (anchorY ?? 1));
                 break;
 
             case 'rightBottom':
             case 'bottomRight':
-                this.layout.x = parentWidth - marginRight - (width * (anchorX ?? 1));
-                this.layout.y = parentHeight - marginBottom - (height * (anchorY ?? 1));
+                this.layout.container.x = parentWidth - marginRight - (width * (anchorX ?? 1));
+                this.layout.container.y = parentHeight - marginBottom - (height * (anchorY ?? 1));
                 break;
 
             case 'center':
-                this.layout.x = (parentWidth / 2) - (width * (anchorX ?? 0.5)) + marginLeft;
-                this.layout.y = (parentHeight / 2) - (height * (anchorY ?? 0.5)) + marginTop;
+                this.layout.container.x = (parentWidth / 2) - (width * (anchorX ?? 0.5)) + marginLeft;
+                this.layout.container.y = (parentHeight / 2) - (height * (anchorY ?? 0.5)) + marginTop;
                 break;
 
             case 'centerTop':
             case 'topCenter':
-                this.layout.x = (parentWidth / 2) - (width * (anchorX ?? 0.5)) + marginLeft;
-                this.layout.y = marginTop - (height * (anchorY ?? 0));
+                this.layout.container.x = (parentWidth / 2) - (width * (anchorX ?? 0.5)) + marginLeft;
+                this.layout.container.y = marginTop - (height * (anchorY ?? 0));
                 break;
 
             case 'centerBottom':
             case 'bottomCenter':
-                this.layout.x = (parentWidth / 2) - (width * (anchorX ?? 0.5)) + marginLeft;
-                this.layout.y = parentHeight - marginBottom - (height * (anchorY ?? 1));
+                this.layout.container.x = (parentWidth / 2) - (width * (anchorX ?? 0.5)) + marginLeft;
+                this.layout.container.y = parentHeight - marginBottom - (height * (anchorY ?? 1));
                 break;
 
             case 'centerLeft':
             case 'leftCenter':
-                this.layout.x = marginLeft - (width * (anchorX ?? 0));
-                this.layout.y = (parentHeight / 2) - (height * (anchorY ?? 0.5)) + marginTop;
+                this.layout.container.x = marginLeft - (width * (anchorX ?? 0));
+                this.layout.container.y = (parentHeight / 2) - (height * (anchorY ?? 0.5)) + marginTop;
                 break;
 
             case 'centerRight':
             case 'rightCenter':
-                this.layout.x = parentWidth - marginRight - (width * (anchorX ?? 1));
-                this.layout.y = (parentHeight / 2) - (height * (anchorY ?? 0.5)) + marginTop;
+                this.layout.container.x = parentWidth - marginRight - (width * (anchorX ?? 1));
+                this.layout.container.y = (parentHeight / 2) - (height * (anchorY ?? 0.5)) + marginTop;
                 break;
 
             case 'leftTop':
@@ -260,8 +261,8 @@ export class AlignController
             case 'left':
             case 'top':
             default:
-                this.layout.x = marginLeft - (width * (anchorX ?? 0));
-                this.layout.y = marginTop - (height * (anchorY ?? 0));
+                this.layout.container.x = marginLeft - (width * (anchorX ?? 0));
+                this.layout.container.y = marginTop - (height * (anchorY ?? 0));
         }
     }
 }

--- a/src/controllers/align/AlignController.ts
+++ b/src/controllers/align/AlignController.ts
@@ -1,4 +1,4 @@
-import { LayoutContainer, LayoutSystem } from '../../Layout';
+import { Layout, LayoutSystem } from '../../Layout';
 import { Text } from '@pixi/text';
 import { isItJustAText } from '../../utils/helpers';
 
@@ -118,7 +118,7 @@ export class AlignController
             let childMarginTop = 0;
             let childMarginBottom = 0;
 
-            if (child instanceof LayoutContainer)
+            if (child instanceof Layout)
             {
                 childDisplay = child.style.display;
                 const childPosition = child.style.position;

--- a/src/stories/autoSize/ByBackground.stories.ts
+++ b/src/stories/autoSize/ByBackground.stories.ts
@@ -1,4 +1,4 @@
-import { Layout } from '../../Layout';
+import { LayoutContainer } from '../../Layout';
 import { argTypes, getDefaultArgs } from '../utils/argTypes';
 import { Container } from '@pixi/display';
 import { preloadAssets } from '../utils/helpers';
@@ -8,29 +8,29 @@ import { ALIGN } from '../../utils/constants';
 const assets = {
     horizontal: 'Window/SmallSubstrate.png',
     vertical: 'Window/MenuWindow.png',
-    small: 'Window/Substrate.png'
+    small: 'Window/Substrate.png',
 };
 
 const args = {
     text:
-    'Background is set to sprite or other display object with width and height.\n'
-    + 'Width and height values are not set.\n'
-    + 'Display is not set, so it is "inline-block" by default.\n'
-    + 'Layout size will adapt to the background size.\n'
-    + 'Text will adapt to the layout width,\n'
-    + 'Height of text will adapt to the text height.',
+        'Background is set to sprite or other display object with width and height.\n'
+        + 'Width and height values are not set.\n'
+        + 'Display is not set, so it is "inline-block" by default.\n'
+        + 'Layout size will adapt to the background size.\n'
+        + 'Text will adapt to the layout width,\n'
+        + 'Height of text will adapt to the text height.',
     background: Object.keys(assets),
     paddingLeft: 55,
     paddingRight: 55,
     paddingTop: 55,
     paddingBottom: 55,
-    textAlign: ALIGN
+    textAlign: ALIGN,
 };
 
 class LayoutStory
 {
-    private layout: Layout;
-    private toolTip: Layout;
+    private layout: LayoutContainer;
+    private toolTip: LayoutContainer;
     view = new Container();
     w: number;
     h: number;
@@ -40,18 +40,26 @@ class LayoutStory
         preloadAssets(Object.values(assets)).then(() => this.createLayout(props));
     }
 
-    createLayout({ background, paddingLeft, paddingRight, paddingTop, paddingBottom, text, textAlign }: any)
+    createLayout({
+        background,
+        paddingLeft,
+        paddingRight,
+        paddingTop,
+        paddingBottom,
+        text,
+        textAlign,
+    }: any)
     {
-        this.layout = new Layout({
+        this.layout = new LayoutContainer({
             id: 'root',
             content: {
                 text: {
                     content: text,
                     styles: {
                         display: 'block',
-                        textAlign
-                    }
-                }
+                        textAlign,
+                    },
+                },
             },
             styles: {
                 background: Sprite.from(assets[background]),
@@ -62,8 +70,8 @@ class LayoutStory
                 paddingLeft,
                 paddingRight,
                 paddingTop,
-                paddingBottom
-            }
+                paddingBottom,
+            },
         });
         this.layout.resize(this.w, this.h);
         this.view.addChild(this.layout);
@@ -84,5 +92,5 @@ export const ByBackground = (params: any) => new LayoutStory(params);
 export default {
     title: 'AutoSize',
     argTypes: argTypes(args),
-    args: getDefaultArgs(args)
+    args: getDefaultArgs(args),
 };

--- a/src/stories/autoSize/ByBackground.stories.ts
+++ b/src/stories/autoSize/ByBackground.stories.ts
@@ -1,4 +1,4 @@
-import { LayoutContainer } from '../../Layout';
+import { Layout } from '../../Layout';
 import { argTypes, getDefaultArgs } from '../utils/argTypes';
 import { Container } from '@pixi/display';
 import { preloadAssets } from '../utils/helpers';
@@ -29,8 +29,8 @@ const args = {
 
 class LayoutStory
 {
-    private layout: LayoutContainer;
-    private toolTip: LayoutContainer;
+    private layout: Layout;
+    private toolTip: Layout;
     view = new Container();
     w: number;
     h: number;
@@ -50,7 +50,7 @@ class LayoutStory
         textAlign,
     }: any)
     {
-        this.layout = new LayoutContainer({
+        this.layout = new Layout({
             id: 'root',
             content: {
                 text: {

--- a/src/stories/autoSize/ByContent.stories.ts
+++ b/src/stories/autoSize/ByContent.stories.ts
@@ -1,4 +1,4 @@
-import { LayoutContainer } from '../../Layout';
+import { Layout } from '../../Layout';
 import { argTypes, getDefaultArgs } from '../utils/argTypes';
 import { Container } from '@pixi/display';
 import { toolTip } from '../components/ToolTip';
@@ -21,8 +21,8 @@ const args = {
 
 class LayoutStory
 {
-    private layout: LayoutContainer;
-    private toolTip: LayoutContainer;
+    private layout: Layout;
+    private toolTip: Layout;
     view = new Container();
     w: number;
     h: number;
@@ -47,7 +47,7 @@ class LayoutStory
             content.push(Sprite.from(assets[image]));
         }
 
-        this.layout = new LayoutContainer({
+        this.layout = new Layout({
             id: 'root',
             content,
             styles: {

--- a/src/stories/autoSize/ByContent.stories.ts
+++ b/src/stories/autoSize/ByContent.stories.ts
@@ -1,4 +1,4 @@
-import { Layout } from '../../Layout';
+import { LayoutContainer } from '../../Layout';
 import { argTypes, getDefaultArgs } from '../utils/argTypes';
 import { Container } from '@pixi/display';
 import { toolTip } from '../components/ToolTip';
@@ -21,8 +21,8 @@ const args = {
 
 class LayoutStory
 {
-    private layout: Layout;
-    private toolTip: Layout;
+    private layout: LayoutContainer;
+    private toolTip: LayoutContainer;
     view = new Container();
     w: number;
     h: number;
@@ -47,7 +47,7 @@ class LayoutStory
             content.push(Sprite.from(assets[image]));
         }
 
-        this.layout = new Layout({
+        this.layout = new LayoutContainer({
             id: 'root',
             content,
             styles: {

--- a/src/stories/autoSize/ByContent.stories.ts
+++ b/src/stories/autoSize/ByContent.stories.ts
@@ -6,14 +6,14 @@ import { preloadAssets } from '../utils/helpers';
 import { Sprite } from '@pixi/sprite';
 import { Content } from '../../utils/types';
 
-const assets = {
+const testAssets = {
     energy: 'Icons/EnergyIcon.png',
     gem: 'Icons/gemIcon.png',
     star: 'Icons/Star.png'
 };
 
 const args = {
-    image: Object.keys(assets),
+    image: Object.keys(testAssets),
     amount: 3,
     padding: 20,
     maxWidth: 95
@@ -35,7 +35,7 @@ class LayoutStory
         + `Size of the layout will change basing on content.`
         );
 
-        preloadAssets(Object.values(assets)).then(() => this.createLayout(props));
+        preloadAssets(Object.values(testAssets)).then(() => this.createLayout(props));
     }
 
     createLayout({ image, padding, amount, maxWidth }: any)
@@ -44,7 +44,7 @@ class LayoutStory
 
         for (let i = 0; i < amount; i++)
         {
-            content.push(Sprite.from(assets[image]));
+            content.push(Sprite.from(testAssets[image]));
         }
 
         this.layout = new Layout({

--- a/src/stories/autoSize/BySetSize.stories.ts
+++ b/src/stories/autoSize/BySetSize.stories.ts
@@ -7,8 +7,8 @@ const TEXTS = ['Width and height values are set in percentage of the parent size
 
 const args = {
     text: TEXTS.join('\n\n'),
-    width: 50,
-    height: 50,
+    width: 350,
+    height: 350,
     padding: 15,
     textAlign: ALIGN
 };
@@ -28,8 +28,8 @@ class LayoutStory
             content: text,
             styles: {
                 background: 'black',
-                width: `${width}%`,
-                height: `${height}%`,
+                width,
+                height,
                 padding,
                 overflow: 'hidden',
                 // text options

--- a/src/stories/basic/Anchor.stories.ts
+++ b/src/stories/basic/Anchor.stories.ts
@@ -79,9 +79,9 @@ class LayoutStory
         {
             const image = this.layout.getChildByID('image');
 
-            if (image && image instanceof Layout)
+            if (image && image.layout)
             {
-                image.content.firstChild.rotation += 0.01 * delta;
+                image.layout.content.firstChild.rotation += 0.01 * delta;
             }
         }
     }

--- a/src/stories/basic/TransformContainer.stories.ts
+++ b/src/stories/basic/TransformContainer.stories.ts
@@ -3,7 +3,6 @@ import { Container } from '@pixi/display';
 import { CSS_COLOR_NAMES, LOREM_TEXT, POSITION, ALIGN } from '../../utils/constants';
 import { toolTip } from '../components/ToolTip';
 import { Layout } from '../../Layout';
-import { preloadAssets } from '../utils/helpers';
 
 const color = Object.keys(CSS_COLOR_NAMES).map((key) => key);
 

--- a/src/stories/basic/TransformContainer.stories.ts
+++ b/src/stories/basic/TransformContainer.stories.ts
@@ -3,6 +3,7 @@ import { Container } from '@pixi/display';
 import { CSS_COLOR_NAMES, LOREM_TEXT, POSITION, ALIGN } from '../../utils/constants';
 import { toolTip } from '../components/ToolTip';
 import { Layout } from '../../Layout';
+import { preloadAssets } from '../utils/helpers';
 
 const color = Object.keys(CSS_COLOR_NAMES).map((key) => key);
 
@@ -23,6 +24,7 @@ const args = {
 class LayoutStory
 {
     private toolTip: Layout;
+    private layoutContainer: Container;
     view: Container;
     w: number;
     h: number;
@@ -41,14 +43,16 @@ class LayoutStory
         position
     }: any)
     {
+        this.view = new Container();
+
         this.addTooltip(`Shows you how to turn any Container into a Layout.\n`
             + `Same works for any other Container based element like Sprite or Graphics.\n`);
 
-        this.view = new Container();
+        this.layoutContainer = new Container().initLayout();
 
-        this.view.initLayout();
+        this.view.addChild(this.layoutContainer);
 
-        this.view.layout?.setStyles({
+        this.layoutContainer.layout?.setStyles({
             background: backgroundColor,
             width: `${width}%`,
             height: `${height}%`,
@@ -63,7 +67,7 @@ class LayoutStory
             borderRadius
         });
 
-        this.view.layout?.addContent(LOREM_TEXT);
+        this.layoutContainer.layout?.addContent(LOREM_TEXT);
 
         this.resize(window.innerWidth, window.innerHeight);
     }
@@ -80,7 +84,7 @@ class LayoutStory
         this.w = w;
         this.h = h;
 
-        this.view.layout?.resize(w, h);
+        this.layoutContainer?.layout?.resize(w, h);
         this.toolTip?.resize(w, h);
     }
 }

--- a/src/stories/components/ToolTip.ts
+++ b/src/stories/components/ToolTip.ts
@@ -1,8 +1,8 @@
-import { LayoutContainer } from '../../Layout';
+import { Layout } from '../../Layout';
 import { FancyButton } from '@pixi/ui';
 import { preloadAssets } from '../utils/helpers';
 
-export async function toolTip(text: string): Promise<LayoutContainer>
+export async function toolTip(text: string): Promise<Layout>
 {
     const assets = {
         closeIcon: 'Icons/CloseIcon.png'
@@ -15,7 +15,7 @@ export async function toolTip(text: string): Promise<LayoutContainer>
         scale: 0.3
     });
 
-    const layout = new LayoutContainer({
+    const layout = new Layout({
         content: [
             {
                 content: text,

--- a/src/stories/components/ToolTip.ts
+++ b/src/stories/components/ToolTip.ts
@@ -1,8 +1,8 @@
-import { Layout } from '../../Layout';
+import { LayoutContainer } from '../../Layout';
 import { FancyButton } from '@pixi/ui';
 import { preloadAssets } from '../utils/helpers';
 
-export async function toolTip(text: string): Promise<Layout>
+export async function toolTip(text: string): Promise<LayoutContainer>
 {
     const assets = {
         closeIcon: 'Icons/CloseIcon.png'
@@ -15,31 +15,27 @@ export async function toolTip(text: string): Promise<Layout>
         scale: 0.3
     });
 
-    const layout = new Layout({
-        id: 'toolTip',
+    const layout = new LayoutContainer({
         content: [
             {
-                id: 'toolTipText',
                 content: text,
                 styles: {
-                    display: 'inline',
-                    padding: 20,
                     color: 'white',
                     fontSize: 16,
                     width: '80%'
                 }
             },
             {
-                id: 'toolTipCloseButton',
                 content: closeButton,
                 styles: {
-                    display: 'inline',
                     position: 'right',
-                    margin: 10
+                    marginTop: 15,
+                    marginRight: 15,
                 }
             }
         ],
         styles: {
+            padding: 20,
             background: '#292c2e',
             width: '96%',
             borderRadius: 20,

--- a/src/stories/dynamic/AddRemoveContent.stories.ts
+++ b/src/stories/dynamic/AddRemoveContent.stories.ts
@@ -4,13 +4,15 @@ import { Container } from '@pixi/display';
 import { toolTip } from '../components/ToolTip';
 import { preloadAssets } from '../utils/helpers';
 import { Sprite } from '@pixi/sprite';
-import { Content } from '../../utils/types';
 import { FancyButton } from '@pixi/ui';
 
-const assets = {
+const testAssets = {
     energy: 'Icons/EnergyIcon.png',
     gem: 'Icons/gemIcon.png',
     star: 'Icons/Star.png',
+};
+
+const assets = {
     button: 'Buttons/SmallButton.png',
     buttonHover: 'Buttons/SmallButton-hover.png',
     buttonDown: 'Buttons/SmallButton-pressed.png',
@@ -19,9 +21,10 @@ const assets = {
 };
 
 const args = {
-    image: Object.keys(assets),
+    image: Object.keys(testAssets),
     padding: 30,
-    maxWidth: 95
+    maxWidth: 95,
+    amount: 2
 };
 
 class LayoutStory
@@ -36,33 +39,13 @@ class LayoutStory
     {
         this.addTooltip(`'+' and '-' buttons will add or remove sprites to the layout.\n`);
 
-        preloadAssets(Object.values(assets)).then(() => this.createLayout(props));
+        preloadAssets(Object.values(assets))
+            .then(() => preloadAssets(Object.values(testAssets)))
+            .then(() => this.createLayout(props));
     }
 
-    createLayout({ image, padding, maxWidth }: any)
+    createLayout({ image, padding, maxWidth, amount }: any)
     {
-        const content: Array<Content> = [];
-
-        content.push();
-
-        this.layout = new Layout({
-            id: 'root',
-            content: {
-                icons: {
-                    content: [Sprite.from(assets[image])],
-                    styles: {
-                        padding
-                    }
-                }
-            },
-            styles: {
-                background: 'black',
-                position: 'center',
-                borderRadius: 20,
-                maxWidth: `${maxWidth}%`
-            }
-        });
-
         const addButton = new FancyButton({
             defaultView: assets.button,
             hoverView: assets.buttonHover,
@@ -79,17 +62,34 @@ class LayoutStory
             iconOffset: { y: -7 }
         });
 
-        this.layout.addContent({
-            id: 'button',
+        const buttonsScale = 0.5;
+
+        this.layout = new Layout({
+            id: 'root',
             content: {
-                content: [addButton, removeButton],
-                styles: {
-                    scale: 0.5
+                icons: {
+                    content: new Array(amount).fill(null).map(() => Sprite.from(testAssets[image])),
+                    styles: {
+                        position: 'center',
+                        padding,
+                        maxWidth: `${maxWidth}%`,
+                        background: 'black',
+                        borderRadius: 20,
+                    }
+                },
+                controls: {
+                    content: [addButton, removeButton],
+                    styles: {
+                        position: 'bottomCenter',
+                        scale: buttonsScale,
+                        marginBottom: -20
+                    }
                 }
             },
             styles: {
-                position: 'leftBottom',
-                marginBottom: -addButton.height - 5
+                position: 'center',
+                width: '100%',
+                height: 250,
             }
         });
 
@@ -97,7 +97,7 @@ class LayoutStory
 
         addButton.onPress.connect(() =>
         {
-            iconsLayout.addContent(Sprite.from(assets[image]));
+            iconsLayout.addContent(Sprite.from(testAssets[image]));
         });
 
         removeButton.onPress.connect(() =>

--- a/src/stories/dynamic/ResizePixiInstance.stories.ts
+++ b/src/stories/dynamic/ResizePixiInstance.stories.ts
@@ -35,14 +35,30 @@ class LayoutStory
     {
         this.addTooltip(`'+' and '-' buttons will change the size of 'gem' sprite and update the layout.`);
 
-        preloadAssets(Object.values(assets)).then(() => this.createLayout(props));
+        preloadAssets(Object.values(assets))
+            .then(() => preloadAssets(Object.values(assets)))
+            .then(() => this.createLayout(props));
     }
 
     createLayout({ padding, maxWidth }: any)
     {
-        const content: Array<Content> = [];
+        const addButton = new FancyButton({
+            defaultView: assets.button,
+            hoverView: assets.buttonHover,
+            pressedView: assets.buttonDown,
+            icon: assets.plus,
+            iconOffset: { y: -7 }
+        });
 
-        content.push();
+        const removeButton = new FancyButton({
+            defaultView: assets.button,
+            hoverView: assets.buttonHover,
+            pressedView: assets.buttonDown,
+            icon: assets.minus,
+            iconOffset: { y: -7 }
+        });
+
+        const buttonsScale = 0.5;
 
         const energy = Sprite.from(assets.energy);
         const gem = Sprite.from(assets.gem);
@@ -54,57 +70,38 @@ class LayoutStory
                 icons: {
                     content: [energy, gem, star],
                     styles: {
-                        padding
+                        position: 'center',
+                        padding,
+                        maxWidth: `${maxWidth}%`,
+                        background: 'black',
+                        borderRadius: 20,
                     }
-                }
+                },
+                controls: {
+                    content: [addButton, removeButton],
+                    styles: {
+                        position: 'bottomCenter',
+                        scale: buttonsScale,
+                        marginBottom: -20
+                    }
+                },
             },
             styles: {
-                background: 'black',
                 position: 'center',
-                borderRadius: 20,
-                maxWidth: `${maxWidth}%`
-            }
-        });
-
-        const plusButton = new FancyButton({
-            defaultView: assets.button,
-            hoverView: assets.buttonHover,
-            pressedView: assets.buttonDown,
-            icon: assets.plus,
-            iconOffset: { y: -7 }
-        });
-
-        const minusButton = new FancyButton({
-            defaultView: assets.button,
-            hoverView: assets.buttonHover,
-            pressedView: assets.buttonDown,
-            icon: assets.minus,
-            iconOffset: { y: -7 }
-        });
-
-        this.layout.addContent({
-            id: 'button',
-            content: {
-                content: [plusButton, minusButton],
-                styles: {
-                    scale: 0.5
-                }
-            },
-            styles: {
-                position: 'leftBottom',
-                marginBottom: -plusButton.height - 5
+                width: '100%',
+                height: 250,
             }
         });
 
         const iconsLayout = this.layout.content.getByID('icons')?.layout;
 
-        plusButton.onPress.connect(() =>
+        addButton.onPress.connect(() =>
         {
             gem.scale.set(gem.scale._x + 0.1);
             iconsLayout?.update();
         });
 
-        minusButton.onPress.connect(() =>
+        removeButton.onPress.connect(() =>
         {
             gem.scale.set(gem.scale._x - 0.1 > 0 ? gem.scale._x - 0.1 : 0);
 

--- a/src/stories/dynamic/ResizePixiInstance.stories.ts
+++ b/src/stories/dynamic/ResizePixiInstance.stories.ts
@@ -4,7 +4,6 @@ import { Container } from '@pixi/display';
 import { toolTip } from '../components/ToolTip';
 import { preloadAssets } from '../utils/helpers';
 import { Sprite } from '@pixi/sprite';
-import { Content } from '../../utils/types';
 import { FancyButton } from '@pixi/ui';
 
 const assets = {

--- a/src/stories/dynamic/ResizePixiInstance.stories.ts
+++ b/src/stories/dynamic/ResizePixiInstance.stories.ts
@@ -96,19 +96,19 @@ class LayoutStory
             }
         });
 
-        const iconsLayout: Layout = this.layout.content.getByID('icons') as Layout;
+        const iconsLayout = this.layout.content.getByID('icons')?.layout;
 
         plusButton.onPress.connect(() =>
         {
             gem.scale.set(gem.scale._x + 0.1);
-            iconsLayout.update();
+            iconsLayout?.update();
         });
 
         minusButton.onPress.connect(() =>
         {
             gem.scale.set(gem.scale._x - 0.1 > 0 ? gem.scale._x - 0.1 : 0);
 
-            iconsLayout.update();
+            iconsLayout?.update();
         });
 
         this.layout.resize(this.w, this.h);

--- a/src/stories/dynamic/UpdateStyles.stories.ts
+++ b/src/stories/dynamic/UpdateStyles.stories.ts
@@ -41,9 +41,23 @@ class LayoutStory
 
     createLayout({ padding, maxWidth, maxHeight }: any)
     {
-        const content: Array<Content> = [];
+        const addButton = new FancyButton({
+            defaultView: assets.button,
+            hoverView: assets.buttonHover,
+            pressedView: assets.buttonDown,
+            icon: assets.plus,
+            iconOffset: { y: -7 }
+        });
 
-        content.push();
+        const removeButton = new FancyButton({
+            defaultView: assets.button,
+            hoverView: assets.buttonHover,
+            pressedView: assets.buttonDown,
+            icon: assets.minus,
+            iconOffset: { y: -7 }
+        });
+
+        const buttonsScale = 0.5;
 
         const energy = Sprite.from(assets.energy);
         const gem = Sprite.from(assets.gem);
@@ -52,62 +66,49 @@ class LayoutStory
         this.layout = new Layout({
             id: 'root',
             content: {
-                energy: {
-                    content: energy,
+                items: {
+                    content: {
+                        energy: {
+                            content: energy,
+                            styles: {
+                                padding: 10
+                            }
+                        },
+                        gem: {
+                            content: gem,
+                            styles: {
+                                padding,
+                                background: 'red'
+                            }
+                        },
+                        star: {
+                            content: star,
+                            styles: {
+                                padding: 10
+                            }
+                        }
+                    },
                     styles: {
-                        padding: 10
+                        background: 'black',
+                        position: 'center',
+                        borderRadius: 20,
+                        maxWidth: `${maxWidth}%`,
+                        maxHeight: `${maxHeight}%`
                     }
                 },
-                gem: {
-                    content: gem,
+                controls: {
+                    content: [addButton, removeButton],
                     styles: {
-                        padding,
-                        background: 'red'
-                    }
-                },
-                star: {
-                    content: star,
-                    styles: {
-                        padding: 10
+                        position: 'bottomCenter',
+                        scale: buttonsScale,
+                        marginBottom: 100
                     }
                 }
             },
             styles: {
-                background: 'black',
                 position: 'center',
-                borderRadius: 20,
-                maxWidth: `${maxWidth}%`,
-                maxHeight: `${maxHeight}%`
-            }
-        });
-
-        const plusButton = new FancyButton({
-            defaultView: assets.button,
-            hoverView: assets.buttonHover,
-            pressedView: assets.buttonDown,
-            icon: assets.plus,
-            iconOffset: { y: -7 }
-        });
-
-        const minusButton = new FancyButton({
-            defaultView: assets.button,
-            hoverView: assets.buttonHover,
-            pressedView: assets.buttonDown,
-            icon: assets.minus,
-            iconOffset: { y: -7 }
-        });
-
-        this.layout.addContent({
-            id: 'button',
-            content: {
-                content: [plusButton, minusButton],
-                styles: {
-                    scale: 0.5
-                }
-            },
-            styles: {
-                position: 'leftBottom',
-                marginBottom: -plusButton.height - 5
+                width: '100%',
+                height: '100%',
             }
         });
 
@@ -117,7 +118,7 @@ class LayoutStory
 
         if (gemLayoutStyle)
         {
-            plusButton.onPress.connect(() =>
+            addButton.onPress.connect(() =>
             {
                 const padding = gemLayoutStyle.padding;
 
@@ -129,7 +130,7 @@ class LayoutStory
                 }
             });
 
-            minusButton.onPress.connect(() =>
+            removeButton.onPress.connect(() =>
             {
                 const padding = gemLayoutStyle.padding;
 

--- a/src/stories/dynamic/UpdateStyles.stories.ts
+++ b/src/stories/dynamic/UpdateStyles.stories.ts
@@ -4,7 +4,6 @@ import { Container } from '@pixi/display';
 import { toolTip } from '../components/ToolTip';
 import { preloadAssets } from '../utils/helpers';
 import { Sprite } from '@pixi/sprite';
-import { Content } from '../../utils/types';
 import { FancyButton } from '@pixi/ui';
 
 const assets = {

--- a/src/stories/utils/argTypes.ts
+++ b/src/stories/utils/argTypes.ts
@@ -48,14 +48,16 @@ export const argTypes = (args: Types) =>
         {
             let min = 0;
 
-            if (key.includes('font'))
+            const number = args[key] as number;
+
+            if (key.includes('font') || key.includes('amount'))
             {
                 min = 1;
             }
 
-            if (args[key] >= 0)
+            if (number >= 0)
             {
-                if (args[key] >= 100)
+                if (number >= 100)
                 {
                     exportArgTypes[key] = {
                         control: {
@@ -66,7 +68,7 @@ export const argTypes = (args: Types) =>
                         },
                     };
                 }
-                else if (args[key] > 10)
+                else if (number > 10)
                 {
                     exportArgTypes[key] = {
                         control: {
@@ -77,7 +79,7 @@ export const argTypes = (args: Types) =>
                         },
                     };
                 }
-                else if (args[key] <= 1)
+                else if (number <= 1)
                 {
                     exportArgTypes[key] = {
                         control: {
@@ -101,7 +103,7 @@ export const argTypes = (args: Types) =>
                 }
             }
             else
-            if (args[key] <= -100)
+            if (number <= -100)
             {
                 exportArgTypes[key] = {
                     control: {
@@ -112,7 +114,7 @@ export const argTypes = (args: Types) =>
                     },
                 };
             }
-            else if (args[key] < -10)
+            else if (number < -10)
             {
                 exportArgTypes[key] = {
                     control: {
@@ -123,7 +125,7 @@ export const argTypes = (args: Types) =>
                     },
                 };
             }
-            else if (args[key] >= -1)
+            else if (number >= -1)
             {
                 exportArgTypes[key] = {
                     control: {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,7 +2,7 @@ import { ALIGN, CSS_COLOR_NAMES } from './constants';
 import { Color, CSSColor, FlexColor, FlexNumber, Styles } from './types';
 import { utils } from '@pixi/core';
 import { TextStyle, TEXT_GRADIENT, Text } from '@pixi/text';
-import { Layout } from '../Layout';
+import { LayoutSystem } from '../Layout';
 
 export function rgba2Hex([r, g, b]: number[]): number
 {
@@ -58,7 +58,7 @@ export function getColor(color: FlexColor): Color
             {
                 return {
                     hex: utils.string2hex(color),
-                    opacity: 1
+                    opacity: 1,
                 };
             }
             else if (color.startsWith('rgba('))
@@ -68,7 +68,7 @@ export function getColor(color: FlexColor): Color
 
                 return {
                     hex: rgba2Hex(rgbData),
-                    opacity: parseFloat(colorData[3])
+                    opacity: parseFloat(colorData[3]),
                 };
             }
             else if (color.startsWith('rgb('))
@@ -78,7 +78,7 @@ export function getColor(color: FlexColor): Color
 
                 return {
                     hex: utils.rgb2hex(rgbData),
-                    opacity: 1
+                    opacity: 1,
                 };
             }
             else if (color.startsWith('hsla('))
@@ -88,14 +88,14 @@ export function getColor(color: FlexColor): Color
 
                 return {
                     hex: hsl2Hex(r, g, b),
-                    opacity: parseFloat(colorData[3])
+                    opacity: parseFloat(colorData[3]),
                 };
             }
             else if (Object.keys(CSS_COLOR_NAMES).includes(color as CSSColor))
             {
                 return {
                     hex: CSS_COLOR_NAMES[color as CSSColor],
-                    opacity: 1
+                    opacity: 1,
                 };
             }
             throw new Error(`Unknown color format: ${color}`);
@@ -103,13 +103,13 @@ export function getColor(color: FlexColor): Color
         case 'number':
             return {
                 hex: color,
-                opacity: 1
+                opacity: 1,
             };
 
         default:
             return {
                 hex: parseInt(color, 16),
-                opacity: 1
+                opacity: 1,
             };
     }
 }
@@ -176,15 +176,15 @@ export function stylesToPixiTextStyles(styles: Styles): Partial<TextStyle>
         whiteSpace: styles?.whiteSpace ?? 'pre',
         wordWrap: styles?.wordWrap ?? true,
         wordWrapWidth: styles?.wordWrapWidth ?? 100,
-        leading: styles?.leading ?? 0
+        leading: styles?.leading ?? 0,
     };
 }
 
 /**
  * Detect if layout is just a wrapper for a text element.
- * @param {Layout} layout - Layout to check.
+ * @param {LayoutSystem} layout - Layout to check.
  */
-export function isItJustAText(layout: Layout): boolean
+export function isItJustAText(layout: LayoutSystem): boolean
 {
     const hasOnly1Child = layout.content.children.size === 1;
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -82,3 +82,13 @@ export type LayoutOptions = {
 export type VerticalAlign = (typeof VERTICAL_ALIGN)[number];
 
 export type SizeControl = 'innerText' | 'background' | 'parentSize' | 'contentSize';
+
+export type ContentType =
+    | 'layout'
+    | 'text'
+    | 'string'
+    | 'container'
+    | 'array'
+    | 'unknown'
+    | 'layoutConfig'
+    | 'object';

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,7 +1,7 @@
 import { TextStyle, TextStyleAlign } from '@pixi/text';
 import { Container } from '@pixi/display';
 import { CSS_COLOR_NAMES, POSITION, DISPLAY, OVERFLOW, VERTICAL_ALIGN } from './constants';
-import { LayoutContainer } from '../Layout';
+import { Layout } from '../Layout';
 
 export type GradeToOne = 0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 1;
 
@@ -21,7 +21,7 @@ export type ContentList = { [ID: string]: Content };
 export type Content =
     | string
     | Container
-    | LayoutContainer
+    | Layout
     | LayoutOptions
     | Content[]
     | ContentList;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,7 +1,7 @@
 import { TextStyle, TextStyleAlign } from '@pixi/text';
 import { Container } from '@pixi/display';
 import { CSS_COLOR_NAMES, POSITION, DISPLAY, OVERFLOW, VERTICAL_ALIGN } from './constants';
-import { Layout } from '../Layout';
+import { LayoutContainer } from '../Layout';
 
 export type GradeToOne = 0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 1;
 
@@ -14,14 +14,20 @@ export type Color = {
 
 export type CSSColor = keyof typeof CSS_COLOR_NAMES;
 
-export type Position = typeof POSITION[number];
-export type Display = typeof DISPLAY[number];
+export type Position = (typeof POSITION)[number];
+export type Display = (typeof DISPLAY)[number];
 
 export type ContentList = { [ID: string]: Content };
-export type Content = string | Container | Layout | LayoutOptions | Content[] | ContentList;
+export type Content =
+    | string
+    | Container
+    | LayoutContainer
+    | LayoutOptions
+    | Content[]
+    | ContentList;
 
 export type Containers = Container[];
-export type Overflow = typeof OVERFLOW[number];
+export type Overflow = (typeof OVERFLOW)[number];
 
 export type AspectRatio = 'static' | 'flex';
 
@@ -73,6 +79,6 @@ export type LayoutOptions = {
     globalStyles?: LayoutStyles;
 };
 
-export type VerticalAlign = typeof VERTICAL_ALIGN[number];
+export type VerticalAlign = (typeof VERTICAL_ALIGN)[number];
 
 export type SizeControl = 'innerText' | 'background' | 'parentSize' | 'contentSize';


### PR DESCRIPTION
Fixes #28

The main change here is that the `Layout` class has been renamed to `LayoutSystem`, and instead of an extension of the Container, it now accepts it as a parameter. 

We also have a new `Layout` class, that behaves the same as the old one, extends Container, and initiates it as Layout.

The main amount of the refactor is caused by renaming and splitting some functions between `LayoutSysyem` and the new `Layout`.

Some stories had to be updated and some docs are changed.