### PR TITLE
29 Unregister and cleanup element from a layout system when removed

### DIFF
--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -271,7 +271,6 @@ export class Layout extends Container
     removeChildByID(id: string)
     {
         this.content.removeContent(id);
-        this.update();
     }
 
     /**

--- a/src/controllers/ContentController.ts
+++ b/src/controllers/ContentController.ts
@@ -1,8 +1,7 @@
-/* eslint-disable no-prototype-builtins */
 /* eslint-disable no-case-declarations */
 import { Layout } from '../Layout';
 import { Content, ContentList, LayoutOptions, LayoutStyles } from '../utils/types';
-import { Container } from '@pixi/display';
+import { Container, DisplayObject } from '@pixi/display';
 import { Text } from '@pixi/text';
 import { Sprite } from '@pixi/sprite';
 import { Graphics } from '@pixi/graphics';
@@ -35,6 +34,8 @@ export class ContentController
         this.layout = layout;
         this.children = new Map();
         this.createContent(content, globalStyles);
+
+        this.layout.on('childRemoved', (child) => this.onChildRemoved(child));
     }
 
     /**
@@ -295,5 +296,29 @@ export class ContentController
             this.layout.removeChild(content);
             this.children.delete(id);
         }
+    }
+
+    protected onChildRemoved(child: DisplayObject)
+    {
+        const registeredChild = this.getChild(child);
+
+        if (registeredChild)
+        {
+            this.children.delete(registeredChild);
+            this.layout.update();
+        }
+    }
+
+    protected getChild(childInstance: DisplayObject): string | undefined
+    {
+        for (const [key, value] of this.children.entries())
+        {
+            if (value === childInstance)
+            {
+                return key;
+            }
+        }
+
+        return undefined;
     }
 }

--- a/src/controllers/ContentController.ts
+++ b/src/controllers/ContentController.ts
@@ -33,7 +33,7 @@ export class ContentController
         this.children = new Map();
         this.createContent(content, globalStyles);
 
-        this.layout.on('childRemoved', (child) => this.onChildRemoved(child));
+        this.layout.container.on('childRemoved', (child) => this.onChildRemoved(child));
     }
 
     /**


### PR DESCRIPTION
Closes #29

In case the element was added with `addContent`, and registered in the content controller, but was removed by `removeChild` from the parent container, we have to clean it up from the `ContentController`. This is what is this PR...
