### PR TITLE
Percentage number values can contain fractions

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -147,17 +147,17 @@ export const CSS_COLOR_NAMES = {
     whitesmoke: 0xf5f5f5,
     yellowgreen: 0x9acd32,
     black: 0x000000,
-};
+} as const;
 
-export const LOREM_TEXT = `Lorem ipsum dolor, sit amet consectetur adipisicing elit. 
+export const LOREM_TEXT = `Lorem ipsum dolor, sit amet consectetur adipisicing elit.
 
-Ab praesentium velit minima unde beatae. Illo earum, rem iure unde nemo, 
+Ab praesentium velit minima unde beatae. Illo earum, rem iure unde nemo,
 
 exercitationem nesciunt et voluptas nisi adipisci, provident cupiditate veritatis magnam?`;
 
-export const DISPLAY = ['block', 'inline-block', 'inline'];
+export const DISPLAY = ['block', 'inline-block', 'inline'] as const;
 
-export const OVERFLOW = ['visible', 'hidden'];
+export const OVERFLOW = ['visible', 'hidden'] as const;
 
 export const POSITION = [
     'center',
@@ -186,7 +186,7 @@ export const POSITION = [
     'bottomCenter',
     'leftCenter',
     'rightCenter',
-];
+] as const;
 
-export const ALIGN: TextStyleAlign[] = ['center', 'left', 'right', 'justify'];
-export const VERTICAL_ALIGN = ['middle', 'top', 'bottom'];
+export const ALIGN: TextStyleAlign[] = ['center', 'left', 'right', 'justify'] as const;
+export const VERTICAL_ALIGN = ['middle', 'top', 'bottom'] as const;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -134,7 +134,7 @@ export function getNumber(value: FlexNumber, maxPercentValue?: number): number
         }
         else if (value.endsWith('%'))
         {
-            const val = parseInt(value.slice(0, -1), 10);
+            const val = parseFloat(value.slice(0, -1));
 
             return Math.floor(maxPercentValue ? (maxPercentValue / 100) * val : val);
         }


### PR DESCRIPTION
Currently all percentages are floored before being converted into pixels.

12.5% of 1000px is currently 120px. After this change 12.5% of 1000px is 125px. 12.5% of 100px remains 12px.

I also added `as const` in a few places. This should turn `OVERFLOW` from `string[]` to `'visible' | 'hidden'`. I made the same change to `CSS_COLOR_NAMES`, `DISPLAY`, `POSITION`, `ALIGN` and `VERTICAL_ALIGN` as well.