### PR TITLE
fix: devtools import path error

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
       "require": "./dist/components/index.js"
     },
     "./devtools": {
-      "types": "./dist/devtools/index.d.ts",
-      "import": "./dist/devtools/index.mjs",
-      "require": "./dist/devtools/index.js"
+      "types": "./dist/devtool/index.d.ts",
+      "import": "./dist/devtool/index.mjs",
+      "require": "./dist/devtool/index.js"
     },
     "./react": {
       "types": "./dist/react/index.d.ts",


### PR DESCRIPTION
When `import '@pixi/layout/devtools'`, the path in package.json is `./dist/devtools/index.d.ts`, however the real path is `./dist/devtool/index.d.ts`. This will cause error.