### PR TITLE
fix: set hitArea to match LayoutContainer size

### DIFF
--- a/src/components/LayoutContainer.ts
+++ b/src/components/LayoutContainer.ts
@@ -5,6 +5,7 @@ import {
     type DestroyOptions,
     Graphics,
     type IRenderLayer,
+    Rectangle,
     Ticker,
 } from 'pixi.js';
 import { BoxSizing, Edge } from 'yoga-layout/load';
@@ -80,6 +81,9 @@ export class LayoutContainer extends Container {
     /** Whether or not the background was created by the user */
     private _isUserBackground: boolean = false;
 
+    /** The hit area for the container */
+    private _hitArea = new Rectangle();
+
     constructor(params: LayoutContainerOptions = {}) {
         const { layout, trackpad, background, ...options } = params;
 
@@ -145,6 +149,9 @@ export class LayoutContainer extends Container {
      */
     override computeLayoutData(computedLayout: ComputedLayout) {
         this._drawBackground(computedLayout);
+        this._hitArea.width = computedLayout.width;
+        this._hitArea.height = computedLayout.height;
+        this.hitArea = this._hitArea;
 
         return {
             x: computedLayout.left,

--- a/tests/__tests__/LayoutContainer.test.ts
+++ b/tests/__tests__/LayoutContainer.test.ts
@@ -1,0 +1,38 @@
+import { Application, type Rectangle } from 'pixi.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LayoutContainer } from '../../src/components';
+import '../../src/index';
+
+async function createApp() {
+    const app = new Application();
+
+    await app.init();
+
+    return app;
+}
+
+describe('LayoutContainer', async () => {
+    let app: Application;
+
+    beforeEach(async () => {
+        app = await createApp();
+    });
+
+    afterEach(() => {
+        app.destroy(true);
+    });
+
+    it('should have the correct sized hit area', async () => {
+        const stage = app.stage;
+        const container = new LayoutContainer({
+            layout: { width: 100, height: 100 },
+        });
+
+        stage.addChild(container);
+
+        app.render();
+
+        expect((container.hitArea! as Rectangle).width).toBe(100);
+        expect((container.hitArea! as Rectangle).height).toBe(100);
+    });
+});


### PR DESCRIPTION
Ensures that the hitArea of the LayoutContainer dynamically updates to match the calculated layout dimensions.

- Fixes an issue where the hitArea was not reflecting the intended interactive area.
- Adds a test case to verify the hitArea dimensions.