### PR TITLE
feat: allow for custom default yoga config

### DIFF
--- a/src/core/Layout.ts
+++ b/src/core/Layout.ts
@@ -1,7 +1,7 @@
 import { type Container } from 'pixi.js';
 import { type Node } from 'yoga-layout';
 import { type OverflowContainer } from '../components/LayoutContainer';
-import { getYoga } from '../yoga';
+import { getYoga, getYogaConfig } from '../yoga';
 import { applyStyle } from './style/applyStyle';
 import { formatStyles } from './style/formatStyles';
 import { type LayoutStyles } from './style/layoutStyles';
@@ -133,7 +133,7 @@ export class Layout {
 
     constructor({ target }: LayoutOptions) {
         this.target = target;
-        this.yoga = getYoga().Node.create();
+        this.yoga = getYoga().Node.create(getYogaConfig());
 
         target.on('added', this._onChildAdded, this);
         target.on('removed', this._onChildRemoved, this);

--- a/src/core/LayoutSystem.ts
+++ b/src/core/LayoutSystem.ts
@@ -1,7 +1,7 @@
 import { type Container, ExtensionType, type System } from 'pixi.js';
 import { Direction, loadYoga } from 'yoga-layout/load';
 import { type OverflowContainer } from '../components/LayoutContainer';
-import { setYoga } from '../yoga';
+import { getYoga, setYoga, setYogaConfig } from '../yoga';
 import { calculatePositionSpecifier } from './mixins/utils/calculatePositionSpecifier';
 import { getPixiSize } from './utils/getPixiSize';
 import { nearlyEqual } from './utils/nearlyEqual';
@@ -55,6 +55,7 @@ export class LayoutSystem implements System<LayoutSystemOptions> {
      */
     public async init(options?: LayoutSystemOptions) {
         setYoga(await loadYoga());
+        setYogaConfig(getYoga().Config.create());
         const { layout } = options ?? {};
         const { autoUpdate, enableDebug, throttle, debugModificationCount } = layout ?? {};
 

--- a/src/yoga.ts
+++ b/src/yoga.ts
@@ -1,4 +1,4 @@
-import { type loadYoga } from 'yoga-layout/load';
+import { type Config, type loadYoga } from 'yoga-layout/load';
 
 export type Yoga = Awaited<ReturnType<typeof loadYoga>>;
 
@@ -18,4 +18,24 @@ export function getYoga(): Yoga {
  */
 export function setYoga(newYoga: Yoga) {
     yoga = newYoga;
+}
+
+let yogaConfig: Config;
+
+/**
+ * Set the Yoga configuration.
+ *
+ * @param config The Yoga configuration.
+ */
+export function setYogaConfig(config: Config) {
+    yogaConfig = config;
+}
+
+/**
+ * Get the Yoga configuration.
+ *
+ * @returns The Yoga configuration.
+ */
+export function getYogaConfig(): Config {
+    return yogaConfig;
 }

--- a/tests/__tests__/Yoga.test.ts
+++ b/tests/__tests__/Yoga.test.ts
@@ -1,0 +1,46 @@
+import { Application } from 'pixi.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ExperimentalFeature } from 'yoga-layout/load';
+import { getYoga, getYogaConfig, setYogaConfig } from '../../src/index';
+
+async function createApp() {
+    const app = new Application();
+
+    await app.init();
+
+    return app;
+}
+
+describe('Yoga', async () => {
+    let app: Application;
+
+    beforeEach(async () => {
+        app = await createApp();
+    });
+
+    afterEach(() => {
+        app.destroy(true);
+    });
+
+    it('should create a default yoga config', async () => {
+        const config = getYogaConfig();
+
+        expect(config).toBeDefined();
+        expect(config.isExperimentalFeatureEnabled(ExperimentalFeature.WebFlexBasis)).toBe(false);
+    });
+
+    it('should allow users to set a custom yoga config', async () => {
+        const config = getYoga().Config.create();
+
+        config.setExperimentalFeatureEnabled(ExperimentalFeature.WebFlexBasis, true);
+        setYogaConfig(config);
+        expect(getYogaConfig()).toBe(config);
+        expect(getYogaConfig().isExperimentalFeatureEnabled(ExperimentalFeature.WebFlexBasis)).toBe(true);
+
+        const spy = vi.spyOn(getYoga().Node, 'create');
+
+        app.stage.layout = {};
+        expect(spy).toHaveBeenCalledWith(config);
+        spy.mockRestore();
+    });
+});


### PR DESCRIPTION
Allows users to provide a custom default Yoga configuration.

- This enables users to configure Yoga with specific settings, such as enabling experimental features, before any layout calculations occur.
- This gives more control over the default Yoga configuration.