### PR TITLE
fix: layout issues with invisible children

### DIFF
--- a/src/core/utils/sort-children.ts
+++ b/src/core/utils/sort-children.ts
@@ -44,6 +44,14 @@ export function onChildAdded(layout: Layout, pixiParent: Container) {
                 break;
             }
         }
+
+        // If the yogaIndex is -1, it means the child was not found in the parent container
+        // This can happen if the child is not part of the layout or is not visible
+        // In this case, we do not insert the child into the Yoga layout
+        if (yogaIndex === -1) {
+            return;
+        }
+
         parentLayout.yoga.insertChild(layout.yoga, yogaIndex);
     }
 }

--- a/tests/__tests__/visibility.test.ts
+++ b/tests/__tests__/visibility.test.ts
@@ -21,7 +21,7 @@ describe('visibility', async () => {
         app.destroy(true);
     });
 
-    it('should render a visible sprite', { timeout: 100000 }, async () => {
+    it('should render a visible sprite', async () => {
         const stage = app.stage;
         const sprite = new Sprite(Texture.WHITE);
         const sprite2 = new Sprite(Texture.WHITE);
@@ -58,5 +58,22 @@ describe('visibility', async () => {
         expect(stageYoga.getChild(0)).toStrictEqual(spriteYoga);
         expect(stageYoga.getChild(1)).toStrictEqual(sprite2Yoga);
         expect(stageYoga.getChild(2)).toStrictEqual(sprite3Yoga);
+    });
+
+    it('should not add an invisible sprite to the layout', async () => {
+        const stage = app.stage;
+        const sprite = new Sprite(Texture.WHITE);
+        const sprite2 = new Sprite(Texture.WHITE);
+
+        stage.layout = {};
+        sprite.visible = false;
+        sprite.layout = {};
+
+        stage.addChild(sprite2);
+
+        // expect add child to not throw an error
+        expect(() => {
+            stage.addChildAt(sprite, 0);
+        }).not.toThrow();
     });
 });


### PR DESCRIPTION
Ensures that invisible children are not added to the Yoga layout.

This prevents errors that can occur when a child that is not visible and not the last child is added to a parent