### PR TITLE
fix: layout direction property in devtool

### DIFF
--- a/src/devtool/propertiesPlugin.ts
+++ b/src/devtool/propertiesPlugin.ts
@@ -170,9 +170,9 @@ const properties = () =>
         },
 
         {
-            prop: 'layoutStyle.direction',
+            prop: 'layoutStyle.flexDirection',
             entry: {
-                label: 'direction',
+                label: 'Flex Direction',
                 section: 'Layout',
                 type: 'select',
                 options: { options: ['row', 'row-reverse', 'column', 'column-reverse'] },


### PR DESCRIPTION
Users can now actually set the flex direction property in the devtool