### PR TITLE
chore: adds branch publishing workflow

### DIFF
--- a/.github/workflows/publish-branch.yaml
+++ b/.github/workflows/publish-branch.yaml
@@ -1,0 +1,36 @@
+name: Publish Branch
+
+on:
+    push:
+        branches:
+            - main
+jobs:
+    release_candidate:
+        runs-on: ubuntu-latest
+        env:
+            NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+            BRANCH_NAME: next
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '24.x'
+                  registry-url: 'https://registry.npmjs.org'
+                  cache: 'npm'
+
+            - run: npm ci
+            - run: npm run build:lib
+
+            - name: Get current package.json version
+              run: echo "PACKAGE_VERSION=$(npm pkg get version | tr -d '"')" >> $GITHUB_ENV
+
+            # get the sort SHA and add it into the environment variables
+            - name: Setup Branch Release Candidate Version
+              run: echo "BRANCH_VERSION=$PACKAGE_VERSION-$BRANCH_NAME.${GITHUB_SHA::7}" >> $GITHUB_ENV
+
+            - name: Bump version
+              run: npm version $BRANCH_VERSION --no-git-tag-version --force
+
+            - name: Publish a new branch release candidate version
+              run: npm publish --tag $BRANCH_NAME


### PR DESCRIPTION
Sets up a GitHub Actions workflow to automatically publish release candidates from a specified branch to npm.

This allows for testing and iteration on new features before they are merged into the main release.
