### PR TITLE
fix: layout updates on reparenting

### DIFF
--- a/src/core/mixins/ContainerMixin.ts
+++ b/src/core/mixins/ContainerMixin.ts
@@ -61,6 +61,14 @@ const mixin: Partial<PrivateContainer> = {
                     }
                 },
             });
+
+            // update the children's layout if they have one to be this container
+            for (const child of this.children) {
+                if (child.layout && child.visible) {
+                    child.layout!._onChildRemoved();
+                    child.layout!._onChildAdded(this as unknown as Container);
+                }
+            }
             if (this.parent && this.visible) {
                 this._layout._onChildAdded(this.parent);
             }

--- a/tests/__tests__/LayoutContainer.test.ts
+++ b/tests/__tests__/LayoutContainer.test.ts
@@ -43,13 +43,17 @@ describe('LayoutContainer method bindings', () => {
     let child1: Container;
     let child2: Container;
 
-    beforeEach(() => {
+    let app: Application;
+
+    beforeEach(async () => {
+        app = await createApp();
         container = new LayoutContainer();
         child1 = new Container();
         child2 = new Container();
     });
 
     afterEach(() => {
+        app.destroy(true);
         container.destroy();
         child1.destroy();
         child2.destroy();
@@ -147,5 +151,21 @@ describe('LayoutContainer method bindings', () => {
 
         expect(labeledChildren).toContain(child1);
         expect(labeledChildren).toContain(child2);
+    });
+
+    it('should attach child to new parent when layout is enabled', () => {
+        const parentContainer = new LayoutContainer();
+
+        parentContainer.addChild(container);
+        container.addChild(child1);
+        child1.addChild(child2);
+
+        child2.layout = true;
+        expect(child2.layout!.yoga.getParent()).toBe(null);
+
+        child1.layout = true;
+        const parent = child2.layout!.yoga.getParent()!;
+
+        expect((parent as any).M.O).toBe((child1.layout!.yoga as any).M.O);
     });
 });


### PR DESCRIPTION
Ensures child layouts are correctly updated when a parent enables layout, maintaining proper layout hierarchy.