### PR TITLE
fix: Adds missing children after becoming visible

### DIFF
--- a/src/core/Layout.ts
+++ b/src/core/Layout.ts
@@ -267,9 +267,12 @@ export class Layout {
     public _onChildAdded(pixiParent: Container): void {
         if (this.hasParent) return;
 
+        if (onChildAdded(this, pixiParent) === false) {
+            return;
+        }
+
         this.hasParent = true;
         this.invalidateRoot();
-        onChildAdded(this, pixiParent);
     }
 
     /**

--- a/src/core/utils/sort-children.ts
+++ b/src/core/utils/sort-children.ts
@@ -18,7 +18,7 @@ export function onChildAdded(layout: Layout, pixiParent: Container) {
     }
 
     if (!parentLayout) {
-        return;
+        return false;
     }
 
     // Detach from previous yoga parent if any
@@ -31,17 +31,19 @@ export function onChildAdded(layout: Layout, pixiParent: Container) {
     const yogaIndex = computeYogaInsertionIndex(layout, pixiParent, overflowContainer);
 
     if (yogaIndex === -1) {
-        return;
+        return false;
     }
 
     // Fast append path
     if (yogaIndex === parentLayout.yoga.getChildCount()) {
         parentLayout.yoga.insertChild(layout.yoga, yogaIndex);
 
-        return;
+        return true;
     }
 
     parentLayout.yoga.insertChild(layout.yoga, yogaIndex);
+
+    return true;
 }
 
 /**


### PR DESCRIPTION
Ensures that children added to the display list after
becoming visible are properly integrated into the layout.

This prevents issues where newly visible elements were not
being added to the layout, leading to incorrect positioning.
