### PR TITLE
feat: Enables disabling of trackpad axes

### DIFF
--- a/docs/docs/guides/core/components.md
+++ b/docs/docs/guides/core/components.md
@@ -190,8 +190,10 @@ Trackpad options you can configure include:
 | `disableEasing`     | `boolean`       | `false`        | Disable momentum scrolling/easing when releasing                 |
 | `xEase`             | `ConstrainEase` | `ScrollSpring` | Custom easing for x-axis scrolling                               |
 | `yEase`             | `ConstrainEase` | `ScrollSpring` | Custom easing for y-axis scrolling                               |
-| `xConstrainPercent` | `number`        | `0`            | Percentage of overflow allowed when dragging beyond x-axis limit |
-| `yConstrainPercent` | `number`        | `0`            | Percentage of overflow allowed when dragging beyond y-axis limit |
+| `xConstrainPercent` | `number`        | `0`            | Percentage of overflow allowed when dragging beyond x-axis limit. Setting this value to a negative number disables x-axis scrolling entirely. |
+
+| `yConstrainPercent` | `number`        | `0`            | Percentage of overflow allowed when dragging beyond y-axis limit. Setting this value to a negative number disables y-axis scrolling entirely. |
+
 
 These options are passed when creating a `LayoutContainer` or `LayoutView`.
 
@@ -207,8 +209,8 @@ const container = new LayoutContainer({
         // Constrain scrolling within bounds
         constrain: true,
 
-        // No x-axis overflow allowed when dragging beyond bounds
-        xConstrainPercent: 0,
+        // No x-axis scrolling allowed when dragging beyond bounds
+        xConstrainPercent: -1,
         // No y-axis overflow allowed when dragging beyond bounds
         yConstrainPercent: 0,
 

--- a/src/components/LayoutContainer.ts
+++ b/src/components/LayoutContainer.ts
@@ -174,14 +174,19 @@ export class LayoutContainer extends Container {
             const targetX = this._trackpad.xAxis.value - deltaX;
             const targetY = this._trackpad.yAxis.value - deltaY;
 
-            this._trackpad.xAxis.value = Math.max(
-                this._trackpad.xAxis.max,
-                Math.min(this._trackpad.xAxis.min, targetX),
-            );
-            this._trackpad.yAxis.value = Math.max(
-                this._trackpad.yAxis.max,
-                Math.min(this._trackpad.yAxis.min, targetY),
-            );
+            if (this._trackpad.xAxis.constrainPercent > 0) {
+                this._trackpad.xAxis.value = Math.max(
+                    this._trackpad.xAxis.max,
+                    Math.min(this._trackpad.xAxis.min, targetX),
+                );
+            }
+
+            if (this._trackpad.yAxis.constrainPercent > 0) {
+                this._trackpad.yAxis.value = Math.max(
+                    this._trackpad.yAxis.max,
+                    Math.min(this._trackpad.yAxis.min, targetY),
+                );
+            }
         });
         Ticker.shared.add(this.update, this);
     }

--- a/src/components/trackpad/SlidingNumber.ts
+++ b/src/components/trackpad/SlidingNumber.ts
@@ -150,7 +150,12 @@ export class SlidingNumber {
         this._prev = this.position;
 
         if (this.constrain) {
-            if (this.constrainPercent === 0) {
+            // If constrain percentage is less than 0 we want to not allow any movement
+            if (this.constrainPercent < 0) {
+                this.position = 0;
+                this._speed = 0;
+                this._hasStopped = true;
+            } else if (this.constrainPercent === 0) {
                 if (this.position > this.min) {
                     this.position = this.min;
                 } else if (this.position < this.max) {

--- a/src/components/trackpad/Trackpad.ts
+++ b/src/components/trackpad/Trackpad.ts
@@ -9,9 +9,15 @@ export interface TrackpadOptions {
     xEase?: ConstrainEase;
     /** Custom easing function for y-axis constraint bouncing */
     yEase?: ConstrainEase;
-    /** Percentage of overflow allowed when dragging beyond x-axis constraints */
+    /**
+     * Percentage of overflow allowed when dragging beyond x-axis constraints
+     * Setting this value to a negative number disables x-axis scrolling entirely.
+     */
     xConstrainPercent?: number;
-    /** Percentage of overflow allowed when dragging beyond y-axis constraints */
+    /**
+     * Percentage of overflow allowed when dragging beyond y-axis constraints
+     * Setting this value to a negative number disables y-axis scrolling entirely.
+     */
     yConstrainPercent?: number;
     /** Maximum speed for both axes. Default: 400 */
     maxSpeed?: number;


### PR DESCRIPTION
Allows users to completely disable horizontal or vertical scrolling on the trackpad by setting the constrain percentage to a negative value.

Updates the documentation to reflect this new functionality.
