### PR TITLE
fix: gap style types

### DIFF
--- a/src/core/style/yogaStyles.ts
+++ b/src/core/style/yogaStyles.ts
@@ -109,13 +109,13 @@ export interface YogaStyles {
     flexDirection?: 'row' | 'column' | 'row-reverse' | 'column-reverse';
 
     /** Space between rows in pixels */
-    rowGap?: number;
+    rowGap?: NumberValue;
 
     /** Space between both rows and columns in pixels */
-    gap?: number;
+    gap?: NumberValue;
 
     /** Space between columns in pixels */
-    columnGap?: number;
+    columnGap?: NumberValue;
 
     /**
      * Growth factor relative to other flex items


### PR DESCRIPTION
Updates the type definitions for `rowGap`, `columnGap`, and `gap` properties to `NumberValue`. This change broadens the acceptable input values, enabling more flexible and robust styling configurations for spacing.
